### PR TITLE
Display in network mapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853d5bcf0b73bd5e6d945b976288621825c7166e9f06c5a035ae1aaf42d1b64f"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +593,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dns-lookup",
  "etherparse",
  "ipnet",
  "netdev",
@@ -614,6 +627,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ pnet = "0.35.0"         # for packet crafting
 anyhow = "1.0.75"       # 
 rand = "0.8.5"          # for random numbers
 etherparse = "0.19.0"
+dns-lookup = "3.0.0"

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -8,6 +8,7 @@ use crate::packets::pkt_dissector::PacketDissector;
 use crate::packets::pkt_sender::PacketSender;
 use crate::packets::pkt_sniffer::PacketSniffer;
 use crate::utils::iface_info::get_default_iface_info;
+use crate::utils::network_info::get_host_name;
 
 
 
@@ -70,17 +71,18 @@ impl NetworkMapper {
             let tcp_packet = pkt_builder.build_tcp_packet(ip, 80);
             pkt_sender.send_tcp(tcp_packet, ip);
             
-            Self::display_progress(i+1, total);
+            Self::display_progress(i+1, total, ip.to_string());
             thread::sleep(Duration::from_secs_f32(0.02));
         }
-        println!("");
     }
 
 
-    fn display_progress(index: usize, total: usize) {
-        print!("\rPackets sent: {}/{}", index, total);
+    
+    fn display_progress(index: usize, total: usize, ip:String) {
+        print!("\rPackets sent: {}/{} - {}", index, total, ip);
         io::stdout().flush().unwrap();
     }
+
 
     
     fn finish_tools(pkt_sniffer: &mut PacketSniffer) -> Vec<Vec<u8>> {
@@ -101,6 +103,9 @@ impl NetworkMapper {
             let mac_addr = PacketDissector::get_src_mac(&packet);
             info.push(mac_addr);
 
+            let device_name = get_host_name(&src_ip);
+            info.push(device_name);
+
             self.active_ips.push(info);
         }
     }
@@ -110,15 +115,15 @@ impl NetworkMapper {
     fn display_result(&self) {
         Self::display_header();
         for host in &self.active_ips{
-            println!("{:<15}  {}", host[0], host[1]);
+            println!("{:<15}  {}  {}", host[0], host[1], host[2]);
         }
     }
 
 
 
     fn display_header() {
-        println!("{:<15}  {:<17}", "IP Address", "MAC Address");
-        println!("{}  {}", "-".repeat(15), "-".repeat(17));
+        println!("\n{:<15}  {:<17}  {}", "IP Address", "MAC Address", "Hostname");
+        println!("{}  {}  {}", "-".repeat(15), "-".repeat(17), "-".repeat(8));
     }
 
 }

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 use std::thread;
+use std::io::{self, Write};
 use ipnet::Ipv4AddrRange;
 use crate::engines::_command_exec::CommandExec;
 use crate::packets::pkt_builder::PacketBuilder;
@@ -55,19 +56,31 @@ impl NetworkMapper {
 
 
 
-    fn send_probes(&self, pkt_builder: &PacketBuilder, pkt_sender: &mut PacketSender) {
-        for ip in Self::get_ip_range() {
-            let tcp_packet = pkt_builder.build_tcp_packet(ip, 80);
-            pkt_sender.send_tcp(tcp_packet, ip);
-        }
-    }
-
-
-
     fn get_ip_range() -> Ipv4AddrRange {
         get_default_iface_info().hosts()
     }
 
+
+
+    fn send_probes(&self, pkt_builder: &PacketBuilder, pkt_sender: &mut PacketSender) {
+        let ip_range    = Self::get_ip_range();
+        let total:usize = ip_range.clone().count();
+
+        for (i, ip) in ip_range.enumerate() {
+            let tcp_packet = pkt_builder.build_tcp_packet(ip, 80);
+            pkt_sender.send_tcp(tcp_packet, ip);
+            
+            Self::display_progress(i+1, total);
+            thread::sleep(Duration::from_secs_f32(0.02));
+        }
+        println!("");
+    }
+
+
+    fn display_progress(index: usize, total: usize) {
+        print!("\rPackets sent: {}/{}", index, total);
+        io::stdout().flush().unwrap();
+    }
 
     
     fn finish_tools(pkt_sniffer: &mut PacketSniffer) -> Vec<Vec<u8>> {
@@ -95,10 +108,17 @@ impl NetworkMapper {
 
 
     fn display_result(&self) {
-        println!("IP and MAC Address");
+        Self::display_header();
         for host in &self.active_ips{
-            println!("{} {}", host[0], host[1]);
+            println!("{:<15}  {}", host[0], host[1]);
         }
+    }
+
+
+
+    fn display_header() {
+        println!("{:<15}  {:<17}", "IP Address", "MAC Address");
+        println!("{}  {}", "-".repeat(15), "-".repeat(17));
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,5 @@ pub mod packets {
 pub mod utils {
     pub mod error_msg;
     pub mod iface_info;
+    pub mod network_info;
 }

--- a/src/utils/network_info.rs
+++ b/src/utils/network_info.rs
@@ -1,0 +1,18 @@
+use dns_lookup::lookup_addr;
+use std::net::IpAddr;
+
+
+
+pub fn get_host_name(ip: &str) -> String {
+    let ip: IpAddr = ip.parse().unwrap();
+    match lookup_addr(&ip) {
+        Ok(hostname) => {
+            if hostname.ends_with(".lan") {
+                hostname.trim_end_matches(".lan").to_string()
+            } else {
+                hostname
+            }
+        }
+        Err(_) => "Unknown".to_string(),
+    }
+}


### PR DESCRIPTION
This pull request adds an improved display in the network mapper and includes other enhancements.

## Port Scanner
    - Shows the progress of sent probes
    - Displays the IP, MAC address, and host name of each target

## Utils
    - Adds a new file for reverse DNS queries