### PR TITLE
Add prelude.rs module for common imports

### DIFF
--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -1,14 +1,8 @@
-use std::time::Duration;
-use std::thread;
-use std::io::{self, Write};
-use ipnet::Ipv4AddrRange;
-use crate::engines::_command_exec::CommandExec;
-use crate::packets::pkt_builder::PacketBuilder;
-use crate::packets::pkt_dissector::PacketDissector;
-use crate::packets::pkt_sender::PacketSender;
-use crate::packets::pkt_sniffer::PacketSniffer;
-use crate::utils::iface_info::get_default_iface_info;
-use crate::utils::network_info::get_host_name;
+use crate::prelude::{
+    Duration, thread, io, Write, Ipv4AddrRange,
+    CommandExec, PacketBuilder, PacketDissector, PacketSender, PacketSniffer,
+    get_default_iface_info, get_host_name
+};
 
 
 

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -1,12 +1,7 @@
-use std::time::Duration;
-use std::thread;
-use std::net::Ipv4Addr;
-use crate::engines::_command_exec::CommandExec;
-use crate::packets::pkt_builder::PacketBuilder;
-use crate::packets::pkt_dissector::PacketDissector;
-use crate::packets::pkt_sender::PacketSender;
-use crate::packets::pkt_sniffer::PacketSniffer;
-use crate::utils::error_msg::display_error_and_exit;
+use crate::prelude::{
+    Duration, thread, Ipv4Addr,
+    CommandExec, PacketBuilder, PacketDissector, PacketSender, PacketSniffer, display_error_and_exit
+};
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //pub mod arg_parser;
 
+pub mod prelude;
+
+
 pub mod engines {
     pub mod _command_exec;
     pub mod netmap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-use std::env;
-use std::collections::HashMap;
-use seeker::engines::_command_exec::CommandExec;
-use seeker::engines::netmap::NetworkMapper;
-use seeker::engines::portscan::PortScanner;
-use seeker::utils::error_msg::display_error_and_exit;
+use seeker::prelude::{
+    env, HashMap, CommandExec, NetworkMapper, PortScanner, display_error_and_exit
+};
 
 
 

--- a/src/packets/pkt_builder.rs
+++ b/src/packets/pkt_builder.rs
@@ -1,9 +1,7 @@
-use pnet::packet::ip::{IpNextHeaderProtocols, IpNextHeaderProtocol};
-use pnet::packet::ipv4::{MutableIpv4Packet, checksum as ip_checksum};
-use pnet::packet::tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum};
-use std::net::Ipv4Addr;
-use rand::Rng;
-use crate::utils::iface_info::{get_default_iface_ip};
+use crate::prelude::{
+    Ipv4Addr, IpNextHeaderProtocols, IpNextHeaderProtocol, MutableIpv4Packet, ip_checksum,
+    MutableTcpPacket, TcpFlags, tcp_checksum, Rng, get_default_iface_ip
+};
 
 
 

--- a/src/packets/pkt_dissector.rs
+++ b/src/packets/pkt_dissector.rs
@@ -1,9 +1,8 @@
-use etherparse::{SlicedPacket, InternetSlice, LinkSlice};
+use crate::prelude::{SlicedPacket, InternetSlice, LinkSlice};
 
 
 
 pub struct PacketDissector;
-
 
 impl PacketDissector {
 

--- a/src/packets/pkt_sender.rs
+++ b/src/packets/pkt_sender.rs
@@ -1,7 +1,6 @@
-use std::net::{Ipv4Addr};
-use pnet::packet::ip::IpNextHeaderProtocols;
-use pnet::packet::ipv4::MutableIpv4Packet;
-use pnet::transport::{transport_channel, TransportChannelType::Layer3, TransportSender};
+use crate::prelude::{
+    Ipv4Addr, IpNextHeaderProtocols, MutableIpv4Packet, transport_channel, Layer3, TransportSender
+};
 
 
 

--- a/src/packets/pkt_sniffer.rs
+++ b/src/packets/pkt_sniffer.rs
@@ -1,8 +1,6 @@
-use std::thread;
-use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicBool, Ordering};
-use pcap::{Device, Capture};
-use crate::utils::iface_info::{get_default_iface_ip, get_network};
+use crate::prelude::{
+    thread, Arc, Mutex, AtomicBool, Ordering, Device, Capture, get_default_iface_ip, get_network
+};
 
 
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,50 @@
+pub use std::{
+    collections::HashMap,
+    env,
+    io::{self, Write},
+    net::{Ipv4Addr, IpAddr},
+    sync::{Arc, Mutex},
+    sync::atomic::{AtomicBool, Ordering},
+    thread,
+    time::Duration,
+};
+
+
+
+
+pub use ipnet::{Ipv4AddrRange, Ipv4Net};
+pub use dns_lookup::lookup_addr;
+pub use etherparse::{SlicedPacket, InternetSlice, LinkSlice};
+pub use netdev::interface::get_default_interface;
+pub use pcap::{Device, Capture};
+pub use pnet::{
+    packet::{
+        ip::{IpNextHeaderProtocols, IpNextHeaderProtocol},
+        ipv4::{MutableIpv4Packet, checksum as ip_checksum},
+        tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum},
+    },
+    transport::{transport_channel, TransportChannelType::Layer3, TransportSender},
+};
+pub use rand::Rng;
+
+
+
+
+pub use crate::engines::{
+    _command_exec::CommandExec,
+    netmap::NetworkMapper,
+    portscan::PortScanner
+};
+
+pub use crate::packets::{
+    pkt_builder::PacketBuilder,
+    pkt_dissector::PacketDissector,
+    pkt_sender::PacketSender,
+    pkt_sniffer::PacketSniffer,
+};
+
+pub use crate::utils::{
+    error_msg::display_error_and_exit,
+    iface_info::{get_default_iface_info, get_default_iface_ip, get_network},
+    network_info::get_host_name
+};

--- a/src/utils/iface_info.rs
+++ b/src/utils/iface_info.rs
@@ -1,6 +1,4 @@
-use netdev::interface::get_default_interface;
-use ipnet::Ipv4Net;
-use std::net::Ipv4Addr;
+use crate::prelude::{Ipv4Addr, Ipv4Net, get_default_interface};
 
 
 

--- a/src/utils/network_info.rs
+++ b/src/utils/network_info.rs
@@ -1,5 +1,4 @@
-use dns_lookup::lookup_addr;
-use std::net::IpAddr;
+use crate::prelude::{IpAddr, lookup_addr};
 
 
 


### PR DESCRIPTION
This PR introduces a new prelude.rs file that centralizes commonly used imports across the project.

The prelude re-exports only the final names/modules (e.g., PacketBuilder, HashMap, PortScanner), so other files can import them with a single use seeker::prelude::*; or selectively as needed.

## Changes
     - Added src/prelude.rs with re-exports of standard library types, external crates, and project modules.
     - Refactored all files to import from prelude instead of declaring repeated imports at the top.

## Benefits
    - Reduces duplicate import declarations.
    - Keeps headers of source files cleaner and easier to read.
    - Makes the most common modules available in a consistent way.