### PR TITLE
Separate PCAP stats display, add micro-sleep, and pre-allocate packet buffer

### DIFF
--- a/src/arg_parser/netmap_parser.rs
+++ b/src/arg_parser/netmap_parser.rs
@@ -9,7 +9,7 @@ pub struct NetMapArgs {
     /// Add a delay between packet transmissions.
     ///
     /// Examples: 0.5 or 1-2 (seconds).
-    #[arg(short, long, default_value = "0.04")]
+    #[arg(short, long, default_value = "0.03")]
     pub delay: String,
 
 

--- a/src/arg_parser/pscan_parser.rs
+++ b/src/arg_parser/pscan_parser.rs
@@ -25,7 +25,7 @@ pub struct PortScanArgs {
     /// Add a delay between packet transmissions.
     ///
     /// Examples: 0.5 or 1-2 (seconds).
-    #[arg(short, long, default_value = "0.04")]
+    #[arg(short, long, default_value = "0.03")]
     pub delay: String,
 
     


### PR DESCRIPTION
## This PR introduces several improvements to the packet processing workflow:

- Separate PCAP stats display: The statistics display for PCAP processing has been decoupled from the main packet processing loop, making it easier to monitor and debug.

- Added micro-sleep: A short sleep interval has been added in the main loop to reduce CPU usage without significantly impacting performance.

- Pre-allocated packet buffer: The packet buffer is now pre-allocated, which reduces dynamic memory allocations during runtime and improves performance.

- Reduced delay time: Overall processing delay has been reduced, resulting in a more responsive system.

These changes together improve performance, reduce CPU load, and make monitoring more straightforward.