### PR TITLE
Split PacketBuilder — new HeaderBuilder now builds headers only

### DIFF
--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -1,4 +1,4 @@
-use std::{thread, time::Duration, collections::HashMap};
+use std::{thread, time::Duration, collections::HashMap, mem};
 use clap::Parser;
 use ipnet::Ipv4AddrRange;
 use crate::arg_parser::{NetMapArgs, PortScanArgs};
@@ -62,12 +62,12 @@ impl NetworkMapper {
         let (ip_range, total, delays) = self.get_data_for_loop();
 
         println!("Sending ICMP probes");
-        for (i, (ip, delay)) in ip_range.into_iter().zip(delays.iter()).enumerate() {
+        for (i, (ip, delay)) in ip_range.into_iter().zip(delays.into_iter()).enumerate() {
             let icmp_packet = pkt_builder.build_icmp_echo_req_packet(ip);
             pkt_sender.send_layer3_icmp(icmp_packet, ip);
             
-            Self::display_progress(i+1, total, ip.to_string(), *delay);
-            thread::sleep(Duration::from_secs_f32(*delay));
+            Self::display_progress(i+1, total, ip.to_string(), delay);
+            thread::sleep(Duration::from_secs_f32(delay));
         }
         println!("");
     }
@@ -78,12 +78,12 @@ impl NetworkMapper {
         let (ip_range, total, delays) = self.get_data_for_loop();
 
         println!("Sending TCP probes");
-        for (i, (ip, delay)) in ip_range.into_iter().zip(delays.iter()).enumerate() {
+        for (i, (ip, delay)) in ip_range.into_iter().zip(delays.into_iter()).enumerate() {
             let tcp_packet = pkt_builder.build_tcp_ip_packet(ip, 80);
             pkt_sender.send_layer3_tcp(tcp_packet, ip);
             
-            Self::display_progress(i+1, total, ip.to_string(), *delay);
-            thread::sleep(Duration::from_secs_f32(*delay));
+            Self::display_progress(i+1, total, ip.to_string(), delay);
+            thread::sleep(Duration::from_secs_f32(delay));
         }
         println!("");
     }
@@ -121,14 +121,16 @@ impl NetworkMapper {
 
 
     fn process_raw_packets(&mut self) {
-        for packet in &self.raw_packets {
-            let src_ip = PacketDissector::get_src_ip(packet);
+        let raw_packets = mem::take(&mut self.raw_packets);
+
+        for packet in raw_packets {
+            let src_ip = PacketDissector::get_src_ip(&packet);
 
             if self.active_ips.contains_key(&src_ip) { continue }
 
             let mut info: Vec<String> = Vec::new();
 
-            let mac_addr = PacketDissector::get_src_mac(packet);
+            let mac_addr = PacketDissector::get_src_mac(&packet);
             info.push(mac_addr);
 
             let device_name = get_host_name(&src_ip);
@@ -156,10 +158,11 @@ impl NetworkMapper {
 
 
 
-    fn display_result(&self) {
+    fn display_result(&mut self) {
         Self::display_header();
+        let active_ips = mem::take(&mut self.active_ips);
 
-        for (ip, host) in &self.active_ips{
+        for (ip, host) in active_ips {
             println!("{}", format!("{:<15}  {}  {}", ip, host[0], host[1]));
 
             if self.args.portscan { 

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -123,7 +123,7 @@ impl NetworkMapper {
     fn process_raw_packets(&mut self) {
         let raw_packets = mem::take(&mut self.raw_packets);
 
-        for packet in raw_packets {
+        for packet in raw_packets.into_iter() {
             let src_ip = PacketDissector::get_src_ip(&packet);
 
             if self.active_ips.contains_key(&src_ip) { continue }

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -128,7 +128,7 @@ impl PortScanner {
     fn process_tcp_packets(&mut self) {
         let tcp_packets = mem::take(&mut self.raw_packets);
 
-        for packet in tcp_packets {
+        for packet in tcp_packets.into_iter() {
             let port = PacketDissector::get_tcp_src_port(&packet);
             self.open_ports.push(port);
         }

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -1,4 +1,4 @@
-use std::{thread, time::Duration};
+use std::{thread, time::Duration, mem};
 use crate::arg_parser::PortScanArgs;
 use crate::pkt_kit::{PacketBuilder, PacketDissector, Layer3PacketSender, PacketSniffer};
 use crate::utils::{
@@ -79,16 +79,17 @@ impl PortScanner {
 
 
 
-    fn send_probes(&self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut Layer3PacketSender) {
+    fn send_probes(&mut self, pkt_builder: &mut PacketBuilder, pkt_sender: &mut Layer3PacketSender) {
         let (ip, delays) = self.get_data_for_loop();
+        let ports        = mem::take(&mut self.ports);
 
-        for (port, delay) in self.ports.iter().zip(delays.iter())  {
+        for (port, delay) in ports.into_iter().zip(delays.into_iter())  {
 
-            let tcp_packet = pkt_builder.build_tcp_ip_packet(self.args.target_ip, *port);
+            let tcp_packet = pkt_builder.build_tcp_ip_packet(self.args.target_ip, port);
             pkt_sender.send_layer3_tcp(tcp_packet, self.args.target_ip);
 
-            Self::display_progress(ip.clone(), *port, *delay);
-            thread::sleep(Duration::from_secs_f32(*delay));
+            Self::display_progress(ip.clone(), port, delay);
+            thread::sleep(Duration::from_secs_f32(delay));
         }
         println!("");
     }
@@ -125,8 +126,10 @@ impl PortScanner {
 
 
     fn process_tcp_packets(&mut self) {
-        for packet in &self.raw_packets {
-            let port = PacketDissector::get_tcp_src_port(packet);
+        let tcp_packets = mem::take(&mut self.raw_packets);
+
+        for packet in tcp_packets {
+            let port = PacketDissector::get_tcp_src_port(&packet);
             self.open_ports.push(port);
         }
     }

--- a/src/engines/tunneling.rs
+++ b/src/engines/tunneling.rs
@@ -22,11 +22,13 @@ impl ProtocolTunneler {
 
 
     pub fn execute(&mut self) {
+        self.send_tcp_over_udp();
     }
 
 
 
-    fn send_() {
+    fn send_tcp_over_udp(&mut self) {
+        
     }
 
 }

--- a/src/pkt_kit/header_builder.rs
+++ b/src/pkt_kit/header_builder.rs
@@ -1,0 +1,107 @@
+use std::net::Ipv4Addr;
+use pnet::datalink::MacAddr;
+use pnet::packet::{
+    util::checksum, Packet,
+    ethernet::{EtherTypes, MutableEthernetPacket},
+    ip::IpNextHeaderProtocol,
+    ipv4::{MutableIpv4Packet, checksum as ip_checksum},
+    icmp::{IcmpTypes, echo_request::{MutableEchoRequestPacket, IcmpCodes}},
+    tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum},
+    udp::{MutableUdpPacket, ipv4_checksum as udp_checksum},
+};
+
+
+
+pub struct HeaderBuilder;
+
+impl HeaderBuilder { 
+
+    pub fn create_tcp_header(
+            tcp_buffer: &mut [u8],
+            src_ip:     Ipv4Addr,
+            src_port:   u16, 
+            dst_ip:     Ipv4Addr,
+            dst_port:   u16
+        ) {  
+            let mut tcp_header = MutableTcpPacket::new(tcp_buffer).unwrap();
+            tcp_header.set_source(src_port);
+            tcp_header.set_destination(dst_port);
+            tcp_header.set_sequence(1);
+            tcp_header.set_flags(TcpFlags::SYN);
+            tcp_header.set_window(64240);
+            tcp_header.set_data_offset(5);
+            let pseudo_header_sum = tcp_checksum(&tcp_header.to_immutable(), &src_ip, &dst_ip);
+            tcp_header.set_checksum(pseudo_header_sum);
+    }
+
+
+
+    pub fn create_udp_header(
+            udp_buffer: &mut [u8],
+            src_ip:     Ipv4Addr,
+            src_port:   u16,
+            dst_ip:     Ipv4Addr,
+            dst_port:   u16
+        ) {
+            let mut udp_header = MutableUdpPacket::new(udp_buffer).unwrap();
+            udp_header.set_source(src_port);
+            udp_header.set_destination(dst_port);
+            udp_header.set_length(8u16);
+
+            let checksum = udp_checksum(&udp_header.to_immutable(), &src_ip, &dst_ip);
+            udp_header.set_checksum(checksum);
+    }
+
+
+
+    pub fn create_icmp_header(
+            icmp_buffer: &mut [u8]
+        ) {
+            let mut icmp_header = MutableEchoRequestPacket::new(icmp_buffer).unwrap();
+            icmp_header.set_icmp_type(IcmpTypes::EchoRequest);
+            icmp_header.set_icmp_code(IcmpCodes::NoCode);
+            icmp_header.set_identifier(0x1234);
+            icmp_header.set_sequence_number(1);
+            icmp_header.set_payload(&[]);
+            icmp_header.set_checksum(0);
+
+            let checksum = checksum(&icmp_header.packet(), 1);
+            icmp_header.set_checksum(checksum);
+    }
+
+
+
+    pub fn create_ip_header(
+            ip_buffer: &mut [u8],
+            len:       u8,
+            protocol:  IpNextHeaderProtocol,
+            src_ip:    Ipv4Addr,
+            dst_ip:Ipv4Addr
+        ) {
+            let mut ip_header = MutableIpv4Packet::new(ip_buffer).unwrap();
+            ip_header.set_version(4);
+            ip_header.set_header_length(5);
+            ip_header.set_total_length(len.into());
+            ip_header.set_ttl(64);
+            ip_header.set_next_level_protocol(protocol);
+            ip_header.set_source(src_ip);
+            ip_header.set_destination(dst_ip);
+
+            let checksum = ip_checksum(&ip_header.to_immutable());
+            ip_header.set_checksum(checksum);
+    }
+
+
+
+    pub fn create_ether_header(
+            ether_buffer: &mut [u8],
+            src_mac:      MacAddr,
+            dst_mac:      MacAddr
+        ) {
+            let mut eth_header = MutableEthernetPacket::new(ether_buffer).unwrap();
+            eth_header.set_source(src_mac);
+            eth_header.set_destination(dst_mac);
+            eth_header.set_ethertype(EtherTypes::Ipv4);
+    }
+
+}

--- a/src/pkt_kit/mod.rs
+++ b/src/pkt_kit/mod.rs
@@ -1,3 +1,6 @@
+pub mod header_builder;
+pub use header_builder::HeaderBuilder;
+
 pub mod pkt_buffer;
 pub use pkt_buffer::{HeaderBuffer, PacketBuffer};
 

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -1,16 +1,8 @@
 use std::net::Ipv4Addr;
-use rand::{Rng, rngs::ThreadRng};
 use pnet::datalink::MacAddr;
-use pnet::packet::{
-    util::checksum, Packet,
-    ethernet::{EtherTypes, MutableEthernetPacket},
-    ip::{IpNextHeaderProtocols, IpNextHeaderProtocol},
-    ipv4::{MutableIpv4Packet, checksum as ip_checksum},
-    icmp::{IcmpTypes, echo_request::{MutableEchoRequestPacket, IcmpCodes}},
-    tcp::{MutableTcpPacket, TcpFlags, ipv4_checksum as tcp_checksum},
-    udp::{MutableUdpPacket, ipv4_checksum as udp_checksum},
-};
-use crate::pkt_kit::{HeaderBuffer, PacketBuffer};
+use pnet::packet::ip::IpNextHeaderProtocols as ProtoID;
+use rand::{Rng, rngs::ThreadRng};
+use crate::pkt_kit::{HeaderBuffer, PacketBuffer, HeaderBuilder};
 use crate::utils::{get_ipv4_addr};
 
 
@@ -21,6 +13,7 @@ pub struct PacketBuilder {
     src_ip:  Ipv4Addr,
     rng:     ThreadRng,
 }
+
 
 
 impl PacketBuilder {
@@ -37,9 +30,13 @@ impl PacketBuilder {
 
 
     pub fn build_tcp_ether_packet(&mut self, src_ip: Ipv4Addr, dst_ip: Ipv4Addr) -> &[u8] {
-        self.create_ether_header();
-        self.create_ip_header(40, IpNextHeaderProtocols::Tcp, src_ip, dst_ip);
-        self.create_tcp_header(src_ip, dst_ip, 80);
+        let src_port = self.rng.gen_range(10000..=65535);
+        let src_mac  = self.random_mac();
+        let dst_mac  = self.random_mac();
+
+        HeaderBuilder::create_ether_header(&mut self.headers.ether, src_mac, dst_mac);
+        HeaderBuilder::create_ip_header(&mut self.headers.ip, 40, ProtoID::Tcp, src_ip, dst_ip);
+        HeaderBuilder::create_tcp_header(&mut self.headers.tcp, src_ip, src_port, dst_ip, 80);
         
         self.packets.tcp_layer2[..14].copy_from_slice(&self.headers.ether);
         self.packets.tcp_layer2[14..34].copy_from_slice(&self.headers.ip);
@@ -50,8 +47,10 @@ impl PacketBuilder {
 
 
     pub fn build_tcp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> &[u8] {
-        self.create_ip_header(40, IpNextHeaderProtocols::Tcp, self.src_ip, dst_ip);
-        self.create_tcp_header(self.src_ip, dst_ip, dst_port);
+        let src_port = self.rng.gen_range(10000..=65535);
+
+        HeaderBuilder::create_ip_header(&mut self.headers.ip, 40, ProtoID::Tcp, self.src_ip, dst_ip);
+        HeaderBuilder::create_tcp_header(&mut self.headers.tcp, self.src_ip, src_port, dst_ip, dst_port);
         
         self.packets.tcp_layer3[..20].copy_from_slice(&self.headers.ip);
         self.packets.tcp_layer3[20..].copy_from_slice(&self.headers.tcp);
@@ -61,9 +60,13 @@ impl PacketBuilder {
 
 
     pub fn build_udp_ether_packet(&mut self, src_ip: Ipv4Addr, dst_ip: Ipv4Addr) -> &[u8] {
-        self.create_ether_header();
-        self.create_ip_header(28, IpNextHeaderProtocols::Udp, src_ip, dst_ip);
-        self.create_udp_header(src_ip, dst_ip, 53);
+        let src_port = self.rng.gen_range(10000..=65535);
+        let src_mac  = self.random_mac();
+        let dst_mac  = self.random_mac();
+
+        HeaderBuilder::create_ether_header(&mut self.headers.ether, src_mac, dst_mac);
+        HeaderBuilder::create_ip_header(&mut self.headers.ip, 28, ProtoID::Udp, src_ip, dst_ip);
+        HeaderBuilder::create_udp_header(&mut self.headers.udp, src_ip, src_port, dst_ip, 53);
 
         self.packets.udp_layer2[..14].copy_from_slice(&self.headers.ether);
         self.packets.udp_layer2[14..34].copy_from_slice(&self.headers.ip);
@@ -74,8 +77,10 @@ impl PacketBuilder {
 
 
     pub fn build_udp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> &[u8] {
-        self.create_ip_header(28, IpNextHeaderProtocols::Udp, self.src_ip, dst_ip);
-        self.create_udp_header(self.src_ip, dst_ip, dst_port);
+        let src_port = self.rng.gen_range(10000..=65535);
+
+        HeaderBuilder::create_ip_header(&mut self.headers.ip, 28, ProtoID::Udp, self.src_ip, dst_ip);
+        HeaderBuilder::create_udp_header(&mut self.headers.udp, self.src_ip, src_port, dst_ip, dst_port);
 
         self.packets.udp_layer3[..20].copy_from_slice(&self.headers.ip);
         self.packets.udp_layer3[20..].copy_from_slice(&self.headers.udp);
@@ -85,85 +90,12 @@ impl PacketBuilder {
 
 
     pub fn build_icmp_echo_req_packet(&mut self, dst_ip: Ipv4Addr) -> &[u8] {
-        self.create_ip_header(28, IpNextHeaderProtocols::Icmp, self.src_ip, dst_ip);
-        self.create_icmp_header();
+        HeaderBuilder::create_ip_header(&mut self.headers.ip, 28, ProtoID::Icmp, self.src_ip, dst_ip);
+        HeaderBuilder::create_icmp_header(&mut self.headers.icmp);
 
         self.packets.icmp_layer3[..20].copy_from_slice(&self.headers.ip);
         self.packets.icmp_layer3[20..].copy_from_slice(&self.headers.icmp);
         &self.packets.icmp_layer3
-    }
-
-
-
-    fn create_tcp_header(&mut self, src_ip: Ipv4Addr, dst_ip: Ipv4Addr, dst_port: u16) {
-        let src_port = self.rng.gen_range(10000..=65535);
-        
-        let mut tcp_header = MutableTcpPacket::new(&mut self.headers.tcp).unwrap();
-        tcp_header.set_source(src_port);
-        tcp_header.set_destination(dst_port);
-        tcp_header.set_sequence(1);
-        tcp_header.set_flags(TcpFlags::SYN);
-        tcp_header.set_window(64240);
-        tcp_header.set_data_offset(5);
-
-        let pseudo_header_sum = tcp_checksum(&tcp_header.to_immutable(), &src_ip, &dst_ip);
-        tcp_header.set_checksum(pseudo_header_sum);
-    }
-
-
-
-    fn create_udp_header(&mut self, src_ip: Ipv4Addr, dst_ip: Ipv4Addr, dst_port: u16) {
-        let src_port = self.rng.gen_range(10000..=65535);
-
-        let mut udp_header = MutableUdpPacket::new(&mut self.headers.udp).unwrap();
-        udp_header.set_source(src_port);
-        udp_header.set_destination(dst_port);
-        udp_header.set_length(8u16);
-
-        let checksum = udp_checksum(&udp_header.to_immutable(), &src_ip, &dst_ip);
-        udp_header.set_checksum(checksum);
-    }
-
-
-
-    fn create_icmp_header(&mut self) {
-        let mut icmp_header = MutableEchoRequestPacket::new(&mut self.headers.icmp).unwrap();
-        icmp_header.set_icmp_type(IcmpTypes::EchoRequest);
-        icmp_header.set_icmp_code(IcmpCodes::NoCode);
-        icmp_header.set_identifier(0x1234);
-        icmp_header.set_sequence_number(1);
-        icmp_header.set_payload(&[]);
-        icmp_header.set_checksum(0);
-
-        let checksum = checksum(&icmp_header.packet(), 1);
-        icmp_header.set_checksum(checksum);
-    }
-
-
-
-    fn create_ip_header(&mut self, len: u8, protocol: IpNextHeaderProtocol, src_ip: Ipv4Addr, dst_ip:Ipv4Addr) {
-        let mut ip_header = MutableIpv4Packet::new(&mut self.headers.ip).unwrap();
-        ip_header.set_version(4);
-        ip_header.set_header_length(5);
-        ip_header.set_total_length(len.into());
-        ip_header.set_ttl(64);
-        ip_header.set_next_level_protocol(protocol);
-        ip_header.set_source(src_ip);
-        ip_header.set_destination(dst_ip);
-
-        let checksum = ip_checksum(&ip_header.to_immutable());
-        ip_header.set_checksum(checksum);
-    }
-
-
-
-    fn create_ether_header(&mut self) {
-        let dst_mac        = self.random_mac();
-        let src_mac        = self.random_mac();
-        let mut eth_header = MutableEthernetPacket::new(&mut self.headers.ether).unwrap();
-        eth_header.set_source(src_mac);
-        eth_header.set_destination(dst_mac);
-        eth_header.set_ethertype(EtherTypes::Ipv4);
     }
 
 


### PR DESCRIPTION
This update refactors the packet construction logic by separating responsibilities:

### Created HeaderBuilder:
- A new implementation dedicated to building protocol headers (Ethernet, IP, TCP, UDP, ICMP, etc.).
- It focuses solely on constructing and managing header data.

### Updated PacketBuilder:
- Now uses the HeaderBuilder to assemble complete packets, improving modularity, readability, and maintainability.

This change lays the groundwork for cleaner extensions and easier testing of each component independently.