### PR TITLE
New function added. Protocol Tunneler

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **Network Mapping**
 - **Port Scanning**
 - **Packet Flooding**
+- **Protocol Tunneling test**
 
 <br>
 

--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -59,10 +59,10 @@ impl PacketFlooder {
             let src_ip = self.get_src_ip();
             let dst_ip = self.get_dst_ip();
             
-            let tcp_pkt = pkt_builder.build_tcp_ether_packet(src_ip, dst_ip);
+            let tcp_pkt = pkt_builder.build_tcp_ether_pkt(src_ip, dst_ip);
             pkt_sender.send_layer2_frame(tcp_pkt);
 
-            let udp_pkt = pkt_builder.build_udp_ether_packet(src_ip, dst_ip);
+            let udp_pkt = pkt_builder.build_udp_ether_pkt(src_ip, dst_ip);
             pkt_sender.send_layer2_frame(udp_pkt);
             
             self.display_progress();

--- a/src/engines/netmap.rs
+++ b/src/engines/netmap.rs
@@ -63,8 +63,8 @@ impl NetworkMapper {
 
         println!("Sending ICMP probes");
         for (i, (ip, delay)) in ip_range.into_iter().zip(delays.into_iter()).enumerate() {
-            let icmp_packet = pkt_builder.build_icmp_echo_req_packet(ip);
-            pkt_sender.send_layer3_icmp(icmp_packet, ip);
+            let icmp_pkt = pkt_builder.build_icmp_echo_req_pkt(ip);
+            pkt_sender.send_layer3_icmp(icmp_pkt, ip);
             
             Self::display_progress(i+1, total, ip.to_string(), delay);
             thread::sleep(Duration::from_secs_f32(delay));
@@ -79,8 +79,8 @@ impl NetworkMapper {
 
         println!("Sending TCP probes");
         for (i, (ip, delay)) in ip_range.into_iter().zip(delays.into_iter()).enumerate() {
-            let tcp_packet = pkt_builder.build_tcp_ip_packet(ip, 80);
-            pkt_sender.send_layer3_tcp(tcp_packet, ip);
+            let tcp_pkt = pkt_builder.build_tcp_ip_pkt(ip, 80);
+            pkt_sender.send_layer3_tcp(tcp_pkt, ip);
             
             Self::display_progress(i+1, total, ip.to_string(), delay);
             thread::sleep(Duration::from_secs_f32(delay));

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -85,8 +85,8 @@ impl PortScanner {
 
         for (port, delay) in ports.into_iter().zip(delays.into_iter())  {
 
-            let tcp_packet = pkt_builder.build_tcp_ip_packet(self.args.target_ip, port);
-            pkt_sender.send_layer3_tcp(tcp_packet, self.args.target_ip);
+            let tcp_pkt = pkt_builder.build_tcp_ip_pkt(self.args.target_ip, port);
+            pkt_sender.send_layer3_tcp(tcp_pkt, self.args.target_ip);
 
             Self::display_progress(ip.clone(), port, delay);
             thread::sleep(Duration::from_secs_f32(delay));

--- a/src/engines/tunneling.rs
+++ b/src/engines/tunneling.rs
@@ -1,3 +1,4 @@
+use std::net::Ipv4Addr;
 use crate::arg_parser::TunnelArgs;
 use crate::pkt_kit::{PacketBuilder, Layer3PacketSender};
 
@@ -28,7 +29,10 @@ impl ProtocolTunneler {
 
 
     fn send_tcp_over_udp(&mut self) {
-        
+        let dst_ip = Ipv4Addr::new(8, 8, 8, 8);
+        let pkt    = self.pkt_builder.build_tcp_over_udp_pkt(dst_ip);
+        self.pkt_sender.send_layer3_udp(pkt, dst_ip);
+        println!("> TCP over UDP packet sent")
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,9 +103,9 @@ impl Command {
 
     
     fn execute_protun(&self) {
-        //let cmd_args   = TunnelArgs::parse_from(self.arguments.clone());
-        //let mut tunnel = ProtocolTunneler::execute(cmd_args);
-        //tunnel.execute();
+        let cmd_args   = TunnelArgs::parse_from(self.arguments.clone());
+        let mut tunnel = ProtocolTunneler::new(cmd_args);
+        tunnel.execute();
     }
 
 }

--- a/src/pkt_kit/header_builder.rs
+++ b/src/pkt_kit/header_builder.rs
@@ -41,12 +41,13 @@ impl HeaderBuilder {
             src_ip:     Ipv4Addr,
             src_port:   u16,
             dst_ip:     Ipv4Addr,
-            dst_port:   u16
+            dst_port:   u16,
+            len:        u16
         ) {
             let mut udp_header = MutableUdpPacket::new(udp_buffer).unwrap();
             udp_header.set_source(src_port);
             udp_header.set_destination(dst_port);
-            udp_header.set_length(8u16);
+            udp_header.set_length(len);
 
             let checksum = udp_checksum(&udp_header.to_immutable(), &src_ip, &dst_ip);
             udp_header.set_checksum(checksum);
@@ -76,7 +77,7 @@ impl HeaderBuilder {
             len:       u8,
             protocol:  IpNextHeaderProtocol,
             src_ip:    Ipv4Addr,
-            dst_ip:Ipv4Addr
+            dst_ip:    Ipv4Addr
         ) {
             let mut ip_header = MutableIpv4Packet::new(ip_buffer).unwrap();
             ip_header.set_version(4);

--- a/src/pkt_kit/layer2_pkt_sender.rs
+++ b/src/pkt_kit/layer2_pkt_sender.rs
@@ -7,7 +7,6 @@ pub struct Layer2PacketSender {
 }
 
 
-
 impl Layer2PacketSender {
 
     pub fn new(iface: String) -> Self{

--- a/src/pkt_kit/mod.rs
+++ b/src/pkt_kit/mod.rs
@@ -2,7 +2,7 @@ pub mod header_builder;
 pub use header_builder::HeaderBuilder;
 
 pub mod pkt_buffer;
-pub use pkt_buffer::{HeaderBuffer, PacketBuffer};
+pub use pkt_buffer::PacketBuffer;
 
 pub mod pkt_builder;
 pub use pkt_builder::PacketBuilder;

--- a/src/pkt_kit/pkt_buffer.rs
+++ b/src/pkt_kit/pkt_buffer.rs
@@ -1,5 +1,5 @@
 pub struct PacketBuffer {
-    pub packet: [u8; 54],
+    pub packet: [u8; 55],
     pub layer4: [u8; 20],
     pub ip:     [u8; 20],
     pub ether:  [u8; 14],
@@ -9,7 +9,7 @@ pub struct PacketBuffer {
 impl Default for PacketBuffer {
     fn default() -> Self {
         Self {
-            packet: [0; 54],
+            packet: [0; 55],
             layer4: [0; 20],
             ip:     [0; 20],
             ether:  [0; 14],

--- a/src/pkt_kit/pkt_buffer.rs
+++ b/src/pkt_kit/pkt_buffer.rs
@@ -1,41 +1,18 @@
-pub struct HeaderBuffer {
-    pub tcp:   [u8; 20],
-    pub udp:   [u8; 8],
-    pub icmp:  [u8; 8],
-    pub ip:    [u8; 20],
-    pub ether: [u8; 14],
-}
-
-impl Default for HeaderBuffer {
-    fn default() -> Self {
-        Self {
-            tcp:   [0; 20],
-            udp:   [0; 8],
-            icmp:  [0; 8],
-            ip:    [0; 20],
-            ether: [0; 14],
-        }
-    }
-}
-
-
-
 pub struct PacketBuffer {
-    pub tcp_layer2:  [u8; 54],
-    pub tcp_layer3:  [u8; 40],
-    pub udp_layer2:  [u8; 42],
-    pub udp_layer3:  [u8; 28],
-    pub icmp_layer3: [u8; 28],
+    pub packet: [u8; 54],
+    pub layer4: [u8; 20],
+    pub ip:     [u8; 20],
+    pub ether:  [u8; 14],
 }
+
 
 impl Default for PacketBuffer {
     fn default() -> Self {
         Self {
-            tcp_layer2:  [0; 54],
-            tcp_layer3:  [0; 40],
-            udp_layer2:  [0; 42],
-            udp_layer3:  [0; 28],
-            icmp_layer3: [0; 28],
+            packet: [0; 54],
+            layer4: [0; 20],
+            ip:     [0; 20],
+            ether:  [0; 14],
         }
     }
 }

--- a/src/pkt_kit/pkt_builder.rs
+++ b/src/pkt_kit/pkt_builder.rs
@@ -2,14 +2,13 @@ use std::net::Ipv4Addr;
 use pnet::datalink::MacAddr;
 use pnet::packet::ip::IpNextHeaderProtocols as ProtoID;
 use rand::{Rng, rngs::ThreadRng};
-use crate::pkt_kit::{HeaderBuffer, PacketBuffer, HeaderBuilder};
-use crate::utils::{get_ipv4_addr};
+use crate::pkt_kit::{PacketBuffer, HeaderBuilder};
+use crate::utils::get_ipv4_addr;
 
 
 
 pub struct PacketBuilder {
-    headers: HeaderBuffer,
-    packets: PacketBuffer,
+    pkt_buf: PacketBuffer,
     src_ip:  Ipv4Addr,
     rng:     ThreadRng,
 }
@@ -20,8 +19,7 @@ impl PacketBuilder {
 
     pub fn new(iface: String, src_ip: Option<Ipv4Addr>) -> Self {
         Self {
-            headers: HeaderBuffer::default(),
-            packets: PacketBuffer::default(),
+            pkt_buf: PacketBuffer::default(),
             src_ip:  src_ip.unwrap_or_else(|| get_ipv4_addr(&iface)),
             rng:     rand::thread_rng(),
         }
@@ -34,14 +32,14 @@ impl PacketBuilder {
         let src_mac  = self.random_mac();
         let dst_mac  = self.random_mac();
 
-        HeaderBuilder::create_ether_header(&mut self.headers.ether, src_mac, dst_mac);
-        HeaderBuilder::create_ip_header(&mut self.headers.ip, 40, ProtoID::Tcp, src_ip, dst_ip);
-        HeaderBuilder::create_tcp_header(&mut self.headers.tcp, src_ip, src_port, dst_ip, 80);
+        HeaderBuilder::create_ether_header(&mut self.pkt_buf.ether, src_mac, dst_mac);
+        HeaderBuilder::create_ip_header(&mut self.pkt_buf.ip, 40, ProtoID::Tcp, src_ip, dst_ip);
+        HeaderBuilder::create_tcp_header(&mut self.pkt_buf.layer4, src_ip, src_port, dst_ip, 80);
         
-        self.packets.tcp_layer2[..14].copy_from_slice(&self.headers.ether);
-        self.packets.tcp_layer2[14..34].copy_from_slice(&self.headers.ip);
-        self.packets.tcp_layer2[34..].copy_from_slice(&self.headers.tcp);
-        &self.packets.tcp_layer2
+        self.pkt_buf.packet[..14].copy_from_slice(&self.pkt_buf.ether);
+        self.pkt_buf.packet[14..34].copy_from_slice(&self.pkt_buf.ip);
+        self.pkt_buf.packet[34..].copy_from_slice(&self.pkt_buf.layer4);
+        &self.pkt_buf.packet
     }
 
 
@@ -49,12 +47,12 @@ impl PacketBuilder {
     pub fn build_tcp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> &[u8] {
         let src_port = self.rng.gen_range(10000..=65535);
 
-        HeaderBuilder::create_ip_header(&mut self.headers.ip, 40, ProtoID::Tcp, self.src_ip, dst_ip);
-        HeaderBuilder::create_tcp_header(&mut self.headers.tcp, self.src_ip, src_port, dst_ip, dst_port);
+        HeaderBuilder::create_ip_header(&mut self.pkt_buf.ip, 40, ProtoID::Tcp, self.src_ip, dst_ip);
+        HeaderBuilder::create_tcp_header(&mut self.pkt_buf.layer4, self.src_ip, src_port, dst_ip, dst_port);
         
-        self.packets.tcp_layer3[..20].copy_from_slice(&self.headers.ip);
-        self.packets.tcp_layer3[20..].copy_from_slice(&self.headers.tcp);
-        &self.packets.tcp_layer3
+        self.pkt_buf.packet[..20].copy_from_slice(&self.pkt_buf.ip);
+        self.pkt_buf.packet[20..40].copy_from_slice(&self.pkt_buf.layer4);
+        &self.pkt_buf.packet[..40]
     }
 
 
@@ -64,14 +62,14 @@ impl PacketBuilder {
         let src_mac  = self.random_mac();
         let dst_mac  = self.random_mac();
 
-        HeaderBuilder::create_ether_header(&mut self.headers.ether, src_mac, dst_mac);
-        HeaderBuilder::create_ip_header(&mut self.headers.ip, 28, ProtoID::Udp, src_ip, dst_ip);
-        HeaderBuilder::create_udp_header(&mut self.headers.udp, src_ip, src_port, dst_ip, 53);
+        HeaderBuilder::create_ether_header(&mut self.pkt_buf.ether, src_mac, dst_mac);
+        HeaderBuilder::create_ip_header(&mut self.pkt_buf.ip, 28, ProtoID::Udp, src_ip, dst_ip);
+        HeaderBuilder::create_udp_header(&mut self.pkt_buf.layer4, src_ip, src_port, dst_ip, 53);
 
-        self.packets.udp_layer2[..14].copy_from_slice(&self.headers.ether);
-        self.packets.udp_layer2[14..34].copy_from_slice(&self.headers.ip);
-        self.packets.udp_layer2[34..].copy_from_slice(&self.headers.udp);
-        &self.packets.udp_layer2
+        self.pkt_buf.packet[..14].copy_from_slice(&self.pkt_buf.ether);
+        self.pkt_buf.packet[14..34].copy_from_slice(&self.pkt_buf.ip);
+        self.pkt_buf.packet[34..42].copy_from_slice(&self.pkt_buf.layer4);
+        &self.pkt_buf.packet[..42]
     }
 
 
@@ -79,23 +77,23 @@ impl PacketBuilder {
     pub fn build_udp_ip_packet(&mut self, dst_ip: Ipv4Addr, dst_port: u16) -> &[u8] {
         let src_port = self.rng.gen_range(10000..=65535);
 
-        HeaderBuilder::create_ip_header(&mut self.headers.ip, 28, ProtoID::Udp, self.src_ip, dst_ip);
-        HeaderBuilder::create_udp_header(&mut self.headers.udp, self.src_ip, src_port, dst_ip, dst_port);
+        HeaderBuilder::create_ip_header(&mut self.pkt_buf.ip, 28, ProtoID::Udp, self.src_ip, dst_ip);
+        HeaderBuilder::create_udp_header(&mut self.pkt_buf.layer4, self.src_ip, src_port, dst_ip, dst_port);
 
-        self.packets.udp_layer3[..20].copy_from_slice(&self.headers.ip);
-        self.packets.udp_layer3[20..].copy_from_slice(&self.headers.udp);
-        &self.packets.udp_layer3
+        self.pkt_buf.packet[..20].copy_from_slice(&self.pkt_buf.ip);
+        self.pkt_buf.packet[20..28].copy_from_slice(&self.pkt_buf.layer4);
+        &self.pkt_buf.packet[..28]
     }
 
 
 
     pub fn build_icmp_echo_req_packet(&mut self, dst_ip: Ipv4Addr) -> &[u8] {
-        HeaderBuilder::create_ip_header(&mut self.headers.ip, 28, ProtoID::Icmp, self.src_ip, dst_ip);
-        HeaderBuilder::create_icmp_header(&mut self.headers.icmp);
+        HeaderBuilder::create_ip_header(&mut self.pkt_buf.ip, 28, ProtoID::Icmp, self.src_ip, dst_ip);
+        HeaderBuilder::create_icmp_header(&mut self.pkt_buf.layer4);
 
-        self.packets.icmp_layer3[..20].copy_from_slice(&self.headers.ip);
-        self.packets.icmp_layer3[20..].copy_from_slice(&self.headers.icmp);
-        &self.packets.icmp_layer3
+        self.pkt_buf.packet[..20].copy_from_slice(&self.pkt_buf.ip);
+        self.pkt_buf.packet[20..28].copy_from_slice(&self.pkt_buf.layer4);
+        &self.pkt_buf.packet[..28]
     }
 
 


### PR DESCRIPTION
This update introduces a new functionality that sends a single packet with a TCP header encapsulated inside a UDP packet.
The feature is designed to support protocol tunneling and firewall behavior testing, without expecting any response from the destination.

### Details
- Added a new function to build and send a TCP-over-UDP packet.
- Uses existing header builders (HeaderBuilder and PacketBuilder) for consistency.
- Intended for network security and filtering evaluation tests.