### PR TITLE
Dependency on crate etherparse removed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,15 +215,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "etherparse"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b119b9796ff800751a220394b8b3613f26dd30c48f254f6837e64c464872d1c7"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -397,7 +382,6 @@ dependencies = [
  "clap",
  "crossbeam",
  "dns-lookup",
- "etherparse",
  "libc",
  "pcap",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,5 @@ clap = { version = "4.5", features = ["derive"] }
 pcap = "2.3.0"
 libc = "0.2.177"
 rand = "0.8.5"
-etherparse = "0.19.0"
 dns-lookup = "3.0.0"
 crossbeam = "0.8.4"

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -137,7 +137,7 @@ impl PortScanner {
         let tcp_packets = mem::take(&mut self.raw_packets);
 
         for packet in tcp_packets.into_iter() {
-            let port = PacketDissector::get_tcp_src_port(&packet);
+            let port = PacketDissector::get_src_tcp_port(&packet);
             self.open_ports.push(port);
         }
     }

--- a/src/pkt_kit/pkt_dissector.rs
+++ b/src/pkt_kit/pkt_dissector.rs
@@ -1,4 +1,4 @@
-use etherparse::{SlicedPacket, InternetSlice};
+use etherparse::{SlicedPacket};
 
 
 
@@ -26,16 +26,19 @@ impl PacketDissector {
 
 
     pub fn get_src_ip(packet: &[u8]) -> String {
-        Self::get_headers(packet)
-            .and_then(|sliced| match sliced.net {
-                Some(InternetSlice::Ipv4(ipv4)) => {
-                    let [a, b, c, d] = ipv4.header().source();
-                    Some(format!("{}.{}.{}.{}", a, b, c, d))
-                }
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_string())
+        if packet.len() < 30 {
+            return "unknown".into();
+        }
+
+        let ethertype = u16::from_be_bytes([packet[12], packet[13]]);
+        if ethertype != 0x0800 {
+            return "unknown".into();
+        }
+
+        let src = &packet[26..30];
+        format!("{}.{}.{}.{}", src[0], src[1], src[2], src[3])
     }
+
 
 
 

--- a/src/pkt_kit/pkt_dissector.rs
+++ b/src/pkt_kit/pkt_dissector.rs
@@ -1,4 +1,4 @@
-use etherparse::{SlicedPacket, InternetSlice, LinkSlice};
+use etherparse::{SlicedPacket, InternetSlice};
 
 
 
@@ -39,33 +39,16 @@ impl PacketDissector {
 
 
 
-    pub fn get_dst_ip(packet: &[u8]) -> String {
-        Self::get_headers(packet)
-            .and_then(|sliced| match sliced.net {
-                Some(InternetSlice::Ipv4(ipv4)) => {
-                    let [a, b, c, d] = ipv4.header().destination();
-                    Some(format!("{}.{}.{}.{}", a, b, c, d))
-                }
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_string())
-    }
-
-
-
     pub fn get_src_mac(packet: &[u8]) -> String {
-        Self::get_headers(packet)
-            .and_then(|sliced| match sliced.link {
-                Some(LinkSlice::Ethernet2(eth)) => Some(
-                    eth.source()
-                        .iter()
-                        .map(|b| format!("{:02x}", b))
-                        .collect::<Vec<_>>()
-                        .join(":"),
-                ),
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_string())
+        if packet.len() < 12 {
+            return "unknown".into();
+        }
+
+        packet[6..12]
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<Vec<_>>()
+            .join(":")
     }
-    
+
 }


### PR DESCRIPTION
Reimplemented basic packet parsing logic (Ethernet, IPv4, and TCP headers) manually to remove the dependency on the etherparse crate. This allows the code to extract source MAC addresses, IP addresses, and TCP ports directly from raw packet data using only the Rust standard library.