### PR TITLE
Add interface name validation and update Wifi Mapper & Auth Flooder

### DIFF
--- a/src/arg_parser/auth_parser.rs
+++ b/src/arg_parser/auth_parser.rs
@@ -1,11 +1,17 @@
 use clap::Parser;
 use crate::arg_parser::parse_mac;
+use crate::iface::IfaceInfo;
 
 
 
 #[derive(Parser)]
 #[command(name = "auth", about = "Authentication flooder")]
 pub struct AuthArgs {
+
+    /// Interface to be use to send the frames
+    #[arg(value_parser = IfaceInfo::check_iface_exists)]
+    pub iface: String,
+
 
     /// SSID (Wifi name)
     pub ssid: String,

--- a/src/arg_parser/flood_parser.rs
+++ b/src/arg_parser/flood_parser.rs
@@ -9,7 +9,11 @@ use crate::iface::IfaceInfo;
 pub struct FloodArgs {
 
     /// Define a network interface to send the packets
-    #[arg(short, long, default_value_t = IfaceInfo::default_iface_name())]
+    #[
+        arg(short, long, 
+        value_parser = IfaceInfo::check_iface_exists,
+        default_value_t = IfaceInfo::default_iface_name())
+    ]
     pub iface: String,
 
 

--- a/src/arg_parser/netmap_parser.rs
+++ b/src/arg_parser/netmap_parser.rs
@@ -14,7 +14,11 @@ pub struct NetMapArgs {
 
 
     /// Define a network interface to send the packets
-    #[arg(short, long, default_value_t = IfaceInfo::default_iface_name())]
+    #[
+        arg(short, long,
+        value_parser = IfaceInfo::check_iface_exists,
+        default_value_t = IfaceInfo::default_iface_name())
+    ]
     pub iface: String,
 
 

--- a/src/arg_parser/protun_parser.rs
+++ b/src/arg_parser/protun_parser.rs
@@ -9,7 +9,11 @@ use crate::iface::IfaceInfo;
 pub struct TunnelArgs {
 
     /// Define a network interface to send the probes
-    #[arg(short, long, default_value_t = IfaceInfo::default_iface_name())]
+    #[
+        arg(short, long, 
+        value_parser = IfaceInfo::check_iface_exists,
+        default_value_t = IfaceInfo::default_iface_name())
+    ]
     pub iface: String,
 
 

--- a/src/arg_parser/wmap_parser.rs
+++ b/src/arg_parser/wmap_parser.rs
@@ -1,9 +1,14 @@
 use clap::Parser;
+use crate::iface::IfaceInfo;
 
 
 #[derive(Parser)]
 #[command(name = "wmap", about = "Packet Flooder")]
 pub struct WmapArgs {
+
+    /// Interface to be use to get the beacons
+    #[arg(value_parser = IfaceInfo::check_iface_exists)]
+    pub iface: String,
 
     /// Set a time to wait before close the beacons capture
     #[arg(short, long, default_value_t = 2)]

--- a/src/iface/iface_info.rs
+++ b/src/iface/iface_info.rs
@@ -163,4 +163,44 @@ impl IfaceInfo {
         }
     }
 
+
+
+    pub fn check_iface_exists(interface_name: &str) -> Result<String, String> {
+        let ifname = CString::new(interface_name)
+            .map_err(|_| "Invalid interface name containing null byte".to_string())?;
+
+        let sock = unsafe { libc::socket(AF_INET, libc::SOCK_DGRAM, 0) };
+        if sock < 0 {
+            return Err("Failed to create socket for interface check".to_string());
+        }
+
+        #[repr(C)]
+        struct IFReq {
+            ifr_name: [libc::c_char; libc::IF_NAMESIZE],
+            ifr_flags: libc::c_short,
+        }
+
+        let mut ifr: IFReq = unsafe { std::mem::zeroed() };
+        unsafe {
+            libc::strcpy(
+                ifr.ifr_name.as_mut_ptr(),
+                ifname.as_ptr() as *const libc::c_char,
+            );
+        }
+
+        let result = unsafe { libc::ioctl(sock, libc::SIOCGIFFLAGS, &mut ifr) };
+
+        unsafe { libc::close(sock); }
+
+        if result == 0 {
+            return Ok(interface_name.to_string());
+        }
+
+        let io_error = std::io::Error::last_os_error();
+        if io_error.raw_os_error() == Some(libc::ENODEV) {
+            return Err("Network interface does not exist".to_string());
+        }
+
+        Err("Failed to check network interface status".to_string())
+    }
 }


### PR DESCRIPTION
This PR introduces a new utility function in IfaceInfo to validate interface names.

### Changes:
- Added check_iface_exist() function: A new method that checks if a user-provided interface name exists and is valid on the system.
- Updated *Wifi Mapper* & *Auth Flooder* parsers: Both components now require the interface argument. The new function is used to verify the provided interface name before proceeding, preventing errors from invalid inputs.

These changes ensure that the tools fail fast with a clear error message if a non-existent interface is specified.