### PR TITLE
Network Interface Enhancements and Bug Fixes

### DIFF
--- a/src/engines/flood.rs
+++ b/src/engines/flood.rs
@@ -4,7 +4,7 @@ use crate::generators::{Ipv4Iter, RandValues};
 use crate::iface::IfaceInfo;
 use crate::pkt_builder::PacketBuilder;
 use crate::sockets::Layer2RawSocket;
-use crate::utils::inline_display;
+use crate::utils::{inline_display, abort};
 
 
 
@@ -41,7 +41,7 @@ impl PacketFlooder {
 
 
     fn set_ip_range(&mut self) {
-        let cidr         = IfaceInfo::iface_network_cidr(&self.args.iface);
+        let cidr         = IfaceInfo::iface_network_cidr(&self.args.iface).unwrap_or_else(|e| abort(e));
         let mut ip_range = Ipv4Iter::new(&cidr, None, None);
         let first_ip     = ip_range.next().expect("No IPs in range");
         let last_ip      = Ipv4Addr::from(u32::from(first_ip) + ip_range.total() as u32 - 3);

--- a/src/engines/portscan.rs
+++ b/src/engines/portscan.rs
@@ -6,7 +6,7 @@ use crate::pkt_builder::{PacketBuilder, UdpPayloads};
 use crate::sniffer::PacketSniffer;
 use crate::sockets::Layer3RawSocket;
 use crate::dissectors::PacketDissector;
-use crate::utils::{inline_display, get_host_name};
+use crate::utils::{inline_display, get_host_name, abort};
 
 
 
@@ -25,7 +25,7 @@ impl PortScanner {
     pub fn new(args: PortScanArgs) -> Self {
         let iface = IfaceInfo::iface_name_from_ip(args.target_ip.clone());
         Self {
-            my_ip:       IfaceInfo::iface_ip(&iface),
+            my_ip:       IfaceInfo::iface_ip(&iface).unwrap_or_else(|e| abort(e)),
             raw_packets: Vec::new(),
             open_ports:  BTreeSet::new(),
             args,

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,8 +117,7 @@ impl Command {
 
 
     fn execute_info(&self) {
-        let mut info = NetworkInfo::new();
-        info.execute();
+        NetworkInfo::execute();
     }
 
 


### PR DESCRIPTION
### New Feature: Gateway MAC Address Display
- Added a new function to NetworkInfo that retrieves the MAC address of the network gateway
- The gateway MAC address is now displayed alongside other interface information in the network info output

### Bug Fix: Interface Existence Check Function
- Fixed a critical bug in the interface existence verification function
- The function was incorrectly returning a boolean (true) instead of the expected interface name (String)
- This caused parsing errors with the clap crate, which expects values compatible with the declared variable type (String)
- Resolution: Modified the function to return the actual interface name as String, resolving the type compatibility issue with clap parsers

### Impact:
- Users can now view gateway MAC addresses in network information displays
- Eliminates runtime errors when specifying interface names via command line arguments
- Maintains backward compatibility while improving type safety in interface validation