### PR TITLE
Add TCP SYN Flooder and Optimize Packet Builder Performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-
-[[package]]
 name = "cc"
 version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,17 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
-name = "mio"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "offscan"
 version = "0.1.0"
 dependencies = [
@@ -219,7 +202,6 @@ dependencies = [
  "libc",
  "pcap",
  "rand",
- "tokio",
 ]
 
 [[package]]
@@ -242,12 +224,6 @@ dependencies = [
  "regex",
  "windows-sys 0.36.1",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
@@ -348,16 +324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "socket2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,32 +338,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tokio"
-version = "1.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "tokio-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -447,12 +387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,21 +409,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-targets"
 version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,3 @@ libc = "0.2.177"
 pcap = "2.3.0"
 rand = "0.8.5"
 clap = { version = "4.5", features = ["derive"] }
-tokio = { version = "1.48.0", features = ["rt", "net", "io-util", "time", "macros"] }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
       <ul style="list-style-type: none; padding-left: 0; margin: 0;">
         <li><strong><em>802.11 Authentication Flooding</em></strong></li>
         <li><strong><em>ICMP (Ping) Flooding</em></strong></li>
+        <li><strong><em>TCP Flooding</em></strong></li>
         <li><strong><em>Packet Flooding</em></strong></li>
         <li><strong><em>Protocol Tunneling test</em></strong></li>
       </ul>

--- a/src/engines/flood_tcp/mod.rs
+++ b/src/engines/flood_tcp/mod.rs
@@ -1,0 +1,2 @@
+pub mod tcp_flood_parser;
+pub use tcp_flood_parser::TcpArgs;

--- a/src/engines/flood_tcp/mod.rs
+++ b/src/engines/flood_tcp/mod.rs
@@ -1,2 +1,5 @@
 pub mod tcp_flood_parser;
 pub use tcp_flood_parser::TcpArgs;
+
+pub mod tcp_flood;
+pub use tcp_flood::TcpFlooder;

--- a/src/engines/flood_tcp/tcp_flood.rs
+++ b/src/engines/flood_tcp/tcp_flood.rs
@@ -1,0 +1,102 @@
+use std::{net::Ipv4Addr, mem};
+use crate::engines::TcpArgs;
+use crate::generators::RandValues;
+use crate::pkt_builder::PacketBuilder;
+use crate::sockets::Layer2RawSocket;
+use crate::utils::{inline_display, get_first_and_last_ip, parse_mac};
+
+
+
+pub struct TcpFlooder {
+    args:      FloodArgs,
+    builder:   PacketBuilder,
+    iface:     String,
+    pkt_data:  PacketData,
+    pkts_sent: usize,
+    rng:       RandValues,
+}
+
+
+#[derive(Default)]
+struct PacketData {
+    src_ip:   Option<Ipv4Addr>,
+    src_mac:  Option<[u8; 6]>,
+    dst_ip:   Ipv4Addr,
+    dst_mac:  [u8; 6],
+    dst_port: u16,
+}
+
+
+
+impl TcpFlooder {
+
+    pub fn new(args: TcpArgs) -> Self {
+        let iface = IfaceInfo::iface_name_from_ip(args.target_ip);
+        let (first_ip, last_ip) = get_first_and_last_ip(&iface);
+
+        Self {
+            args,
+            iface,
+            builder:   PacketBuilder::new(),
+            pkt_data:  Default::default(),
+            pkts_sent: 0,
+            rng:       RandValues::new(Some(first_ip), Some(last_ip)),
+        }
+    }
+
+
+
+    pub fn execute(&mut self){
+        self.send_endlessly();
+    }
+
+
+
+    fn set_pkt_data(&mut self) {
+        self.pkt_data.dst_port = mem::take(mut self.args.port);
+        self.pkt_data.dst_ip   = mem::take(self.args.target_ip);
+        self.pkt_data.dst_mac  = self.resolve_mac(Some(self.args.target_mac));
+    }
+
+
+
+    fn resolve_mac(&self, input_mac: Option<String>) -> Option<[u8; 6]> {
+        if input_mac.is_none() {
+            return None;
+        }
+
+        let mac = input_mac.unwrap();
+
+        let mac_to_parse = if mac == "gateway" {
+            IfaceInfo::gateway_mac(&self.iface)
+        } else {
+            mac
+        };
+
+        match parse_mac(&mac_to_parse) {
+            Err(e)  => { abort(e) },
+            Ok(mac) => { Some(mac) },    
+        }
+    }
+
+
+
+    fn send_endlessly(&mut self) {
+        let socket = Layer2RawSocket::new(&self.iface);
+
+        loop {
+            self.pkts_sent += 1;
+            
+            inline_display(&format!("Packets sent: {}", &self.pkts_sent));
+        }
+    }
+
+
+    #[inline]
+    fn get_pkt(&mut self) -> &[u8] {
+        builder.tcp_ether(
+            src_mac, src_ip, src_port,
+            dst_mac, dst_ip, );
+    }
+
+}

--- a/src/engines/flood_tcp/tcp_flood.rs
+++ b/src/engines/flood_tcp/tcp_flood.rs
@@ -38,6 +38,7 @@ impl TcpFlooder {
 
     pub fn execute(&mut self){
         self.set_pkt_data();
+        self.display_pkt_data();
         self.send_endlessly();
     }
 
@@ -62,7 +63,7 @@ impl TcpFlooder {
 
         let mac_to_parse = match mac.as_str() {
             "gateway" => IfaceInfo::gateway_mac(&self.iface).unwrap().to_string(),
-            "local"   => IfaceInfo::iface_ip(&self.iface).unwrap().to_string(),
+            "local"   => IfaceInfo::get_mac(&self.iface),
             _         => mac
         };
 
@@ -70,6 +71,33 @@ impl TcpFlooder {
             Err(e)  => { abort(e) },
             Ok(mac) => { Some(mac) },    
         }
+    }
+
+
+    
+    fn display_pkt_data(&self) {
+        let src_mac = match self.pkt_data.src_mac {
+            Some(mac) => Self::format_mac(mac),
+            None      => "Random".to_string(),
+        };
+
+        let src_ip = match self.pkt_data.src_ip {
+            Some(ip) => ip.to_string(),
+            None     => "Random".to_string(),
+        };
+
+        println!("SRC >> MAC: {}  IP: {}", src_mac, src_ip);
+        println!("DST >> MAC: {}  IP: {}", Self::format_mac(self.pkt_data.dst_mac), self.pkt_data.dst_ip);
+        println!("IFACE: {}", self.iface);
+    }
+
+
+
+    fn format_mac(mac: [u8; 6]) -> String {
+        format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        )
     }
 
 
@@ -87,6 +115,7 @@ impl TcpFlooder {
     }
 
 
+    
     #[inline]
     fn get_pkt(&mut self) -> &[u8] {
         self.builder.tcp_ether(

--- a/src/engines/flood_tcp/tcp_flood_args.rs
+++ b/src/engines/flood_tcp/tcp_flood_args.rs
@@ -1,0 +1,34 @@
+use std::net::Ipv4Addr;
+use clap::Parser;
+
+
+
+#[derive(Parser)]
+#[command(name = "tcp", about = "TCP Flooder")]
+pub struct TcpArgs {
+
+    /// Target IP address to flood
+    pub target_ip: Ipv4Addr,
+
+
+    /// Use "gateway" if the target isn't in the intranet
+    pub target_mac: String,
+
+
+    /// Target port
+    pub port: u16,
+
+
+    /// Optional source IP address
+    pub src_ip: Option<Ipv4Addr>,
+
+
+    /// Optional source MAC address
+    pub src_mac: Option<String>,
+
+
+    /// Use ACK packets
+    #[arg(long)]
+    pub ack: bool,
+
+}

--- a/src/engines/flood_tcp/tcp_flood_parser.rs
+++ b/src/engines/flood_tcp/tcp_flood_parser.rs
@@ -20,10 +20,12 @@ pub struct TcpArgs {
 
 
     /// Optional source IP address
+    #[arg(long)]
     pub src_ip: Option<Ipv4Addr>,
 
 
     /// Use "local" to use the interface MAC address
+    #[arg(long)]
     pub src_mac: Option<String>,
 
 

--- a/src/engines/flood_tcp/tcp_flood_parser.rs
+++ b/src/engines/flood_tcp/tcp_flood_parser.rs
@@ -23,7 +23,7 @@ pub struct TcpArgs {
     pub src_ip: Option<Ipv4Addr>,
 
 
-    /// Optional source MAC address
+    /// Use "local" to use the interface MAC address
     pub src_mac: Option<String>,
 
 

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -7,6 +7,9 @@ pub use banner_grab::*;
 pub mod flood_ping;
 pub use flood_ping::*;
 
+pub mod flood_tcp;
+pub use flood_tcp::*;
+
 pub mod flood;
 pub use flood::*;
 

--- a/src/engines/net_info/net_info.rs
+++ b/src/engines/net_info/net_info.rs
@@ -109,24 +109,11 @@ impl NetworkInfo {
 
 
 
-    fn get_gateway_mac(interface: &str) -> String {
-        let arp_content = match fs::read_to_string("/proc/net/arp") {
-            Ok(content) => content,
-            Err(_) => return "Unknown".to_string(),
-        };
-
-        for line in arp_content.lines().skip(1) {
-            let fields: Vec<&str> = line.split_whitespace().collect();
-
-            if fields.len() >= 6 && fields[5] == interface {
-                let mac = fields[3];
-                if !mac.is_empty() && mac != "00:00:00:00:00:00" {
-                    return mac.to_string();
-                }
-            }
+    fn get_gateway_mac(iface: &str) -> String {
+        match IfaceInfo::gateway_mac(iface) {
+            Ok(mac) => { mac },
+            Err(_)  => { "Unknown".to_string() }
         }
-
-        "Unknown".to_string()
     }
 
 

--- a/src/iface/iface_info.rs
+++ b/src/iface/iface_info.rs
@@ -67,7 +67,7 @@ impl IfaceInfo {
 
 
 
-    fn gateway_mac(iface: &str) -> Result<String, String> {
+    pub fn gateway_mac(iface: &str) -> Result<String, String> {
         let arp_content = match fs::read_to_string("/proc/net/arp") {
             Ok(content) => content,
             Err(_)      => return Err("Unknown".to_string()),

--- a/src/iface/iface_info.rs
+++ b/src/iface/iface_info.rs
@@ -67,13 +67,39 @@ impl IfaceInfo {
 
 
 
+    fn gateway_mac(iface: &str) -> Result<String, String> {
+        let arp_content = match fs::read_to_string("/proc/net/arp") {
+            Ok(content) => content,
+            Err(_)      => return Err("Unknown".to_string()),
+        };
+
+        for line in arp_content.lines().skip(1) {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+
+            if fields.len() < 6 || fields[5] != iface {
+                continue;
+            }
+
+            let mac = fields[3];
+            if mac.is_empty() || mac == "00:00:00:00:00:00" {
+                continue
+            }
+            
+            return Ok(mac.to_string());
+        }
+
+        Err("Unknown".to_string())
+    }
+
+
+
     pub fn check_iface_exists(iface_name: &str) -> Result<String, String> {
         let interfaces = Self::get_iface_names();
     
         if interfaces.iter().any(|iface| iface == iface_name) {
             Ok(iface_name.to_string())
         } else {
-            Err("Network interface does not exist".to_string())
+            Err("Network iface does not exist".to_string())
         }
     }
 
@@ -85,7 +111,7 @@ impl IfaceInfo {
         match fs::read_to_string(&ifindex_path) {
             Ok(content) => {
                 content.trim().parse().unwrap_or_else(|_| {
-                    abort(&format!("Failed to parse ifindex for interface: {}", iface_name));
+                    abort(&format!("Failed to parse ifindex for iface: {}", iface_name));
                 })
             }
             Err(_) => {
@@ -138,7 +164,7 @@ impl IfaceInfo {
             }
 
             freeifaddrs(ifap);
-            abort(format!("Could not find any interface with IP {}", ip));
+            abort(format!("Could not find any iface with IP {}", ip));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ impl Command {
             "ping"   => self.execute_ping(),
             "pscan"  => self.execute_pscan(),
             "protun" => self.execute_protun(),
+            "tcp"    => self.execute_tcp_flood(),
             "wmap"   => self.execute_wmap(),
             _        => abort(format!("No command '{}'", self.command)),
         }
@@ -86,6 +87,7 @@ impl Command {
         println!("\tping   -> Ping Flooding");
         println!("\tpscan  -> Port Scanning");
         println!("\tprotun -> Protocol Tunneling");
+        println!("\ttcp    -> TCP Flooding");
         println!("\twmap   -> Wifi Mapping");
         println!("");
     }
@@ -157,6 +159,14 @@ impl Command {
         let cmd_args   = TunnelArgs::parse_from(self.get_arguments());
         let mut tunnel = ProtocolTunneler::new(cmd_args);
         tunnel.execute();
+    }
+
+
+
+    fn execute_tcp_flood(&mut self) {
+        let cmd_args = TcpArgs::parse_from(self.get_arguments());
+        let mut tcp  = TcpFlooder::new(cmd_args);
+        tcp.execute();
     }
 
     

--- a/src/pkt_builder/pkt_builder.rs
+++ b/src/pkt_builder/pkt_builder.rs
@@ -4,10 +4,7 @@ use crate::pkt_builder::HeaderBuilder;
 
 
 pub struct PacketBuilder {
-    packet: [u8; 347],
-    layer4: [u8; 313],
-    ip:     [u8; 20],
-    ether:  [u8; 14],
+    buffer: [u8; 347],
 }
 
 
@@ -15,12 +12,7 @@ pub struct PacketBuilder {
 impl PacketBuilder {
 
     pub fn new() -> Self {
-        Self {
-            packet: [0; 347],
-            layer4: [0; 313],
-            ip:     [0; 20],
-            ether:  [0; 14],
-        }
+        Self { buffer: [0; 347] }
     }
 
 
@@ -34,12 +26,10 @@ impl PacketBuilder {
         dst_port: u16,
         ) -> &[u8]
     {
-        HeaderBuilder::tcp(&mut self.layer4, src_ip, src_port, dst_ip, dst_port);
-        HeaderBuilder::ip(&mut self.ip, 40, 6, src_ip, dst_ip);
+        HeaderBuilder::tcp(&mut self.buffer[20..40], src_ip, src_port, dst_ip, dst_port);
+        HeaderBuilder::ip(&mut self.buffer[..20], 40, 6, src_ip, dst_ip);
         
-        self.packet[..20].copy_from_slice(&self.ip);
-        self.packet[20..40].copy_from_slice(&self.layer4[..20]);
-        &self.packet[..40]
+        &self.buffer[..40]
     }
 
 
@@ -55,17 +45,19 @@ impl PacketBuilder {
         ) -> &[u8]
     {
         let len_payload: usize = payload.len().try_into().unwrap();
-        let len_udp: usize     = 8 + len_payload;
-        let len_pkt: usize     = 20 + len_udp;
+        let len_pkt:     usize = 28 + len_payload;
         
-        self.layer4[8..len_udp].copy_from_slice(&payload);
+        self.buffer[28..len_pkt].copy_from_slice(&payload);
 
-        HeaderBuilder::udp(&mut self.layer4, src_ip, src_port, dst_ip, dst_port, len_payload as u16);
-        HeaderBuilder::ip(&mut self.ip, len_pkt as u16, 17, src_ip, dst_ip);
+        HeaderBuilder::udp(
+            &mut self.buffer[20..len_pkt],
+            src_ip, src_port,
+            dst_ip, dst_port, len_payload as u16
+        );
+        
+        HeaderBuilder::ip(&mut self.buffer[..20], len_pkt as u16, 17, src_ip, dst_ip);
 
-        self.packet[..20].copy_from_slice(&self.ip);
-        self.packet[20..len_pkt].copy_from_slice(&self.layer4[..len_udp]);
-        &self.packet[..len_pkt]
+        &self.buffer[..len_pkt]
     }
 
 
@@ -77,12 +69,10 @@ impl PacketBuilder {
         dst_ip: Ipv4Addr,
         ) -> &[u8]
     {
-        HeaderBuilder::icmp(&mut self.layer4);
-        HeaderBuilder::ip(&mut self.ip, 28, 1, src_ip, dst_ip);
+        HeaderBuilder::icmp(&mut self.buffer[20..28]);
+        HeaderBuilder::ip(&mut self.buffer[..20], 28, 1, src_ip, dst_ip);
 
-        self.packet[..20].copy_from_slice(&self.ip);
-        self.packet[20..28].copy_from_slice(&self.layer4[..8]);
-        &self.packet[..28]
+        &self.buffer[..28]
     }
 
 
@@ -100,18 +90,12 @@ impl PacketBuilder {
         dst_tcp_port: u16
         ) -> &[u8]
     {
-        let mut tcp_buffer = [0u8; 27];        
+        HeaderBuilder::tcp(&mut self.buffer[42..69], src_ip, src_tcp_port, dst_ip, dst_tcp_port);
+        HeaderBuilder::udp(&mut self.buffer[34..42], src_ip, src_udp_port, dst_ip, dst_udp_port, 0);
+        HeaderBuilder::ip(&mut self.buffer[14..34], 40, 17, src_ip, dst_ip);
+        HeaderBuilder::ether(&mut self.buffer[..14], src_mac, dst_mac);
 
-        HeaderBuilder::tcp(&mut tcp_buffer, src_ip, src_tcp_port, dst_ip, dst_tcp_port);
-        HeaderBuilder::udp(&mut self.layer4, src_ip, src_udp_port, dst_ip, dst_udp_port, 0);
-        HeaderBuilder::ip(&mut self.ip, 40, 17, src_ip, dst_ip);
-        HeaderBuilder::ether(&mut self.ether, src_mac, dst_mac);
-
-        self.packet[..14].copy_from_slice(&self.ether);
-        self.packet[14..34].copy_from_slice(&self.ip);
-        self.packet[34..42].copy_from_slice(&self.layer4[..8]);
-        self.packet[42..69].copy_from_slice(&tcp_buffer);
-        &self.packet[..69]
+        &self.buffer[..69]
     }
 
 
@@ -127,14 +111,11 @@ impl PacketBuilder {
         dst_port: u16,
         ) -> &[u8]
     {
-        HeaderBuilder::tcp(&mut self.layer4, src_ip, src_port, dst_ip, dst_port);
-        HeaderBuilder::ip(&mut self.ip, 40, 6, src_ip, dst_ip);
-        HeaderBuilder::ether(&mut self.ether, src_mac, dst_mac);
+        HeaderBuilder::tcp(&mut self.buffer[34..54], src_ip, src_port, dst_ip, dst_port);
+        HeaderBuilder::ip(&mut self.buffer[14..34], 40, 6, src_ip, dst_ip);
+        HeaderBuilder::ether(&mut self.buffer[..14], src_mac, dst_mac);
         
-        self.packet[..14].copy_from_slice(&self.ether);
-        self.packet[14..34].copy_from_slice(&self.ip);
-        self.packet[34..54].copy_from_slice(&self.layer4[..20]);
-        &self.packet[..54]
+        &self.buffer[..54]
     }
 
 
@@ -150,14 +131,11 @@ impl PacketBuilder {
         dst_port: u16,
         ) -> &[u8]
     {
-        HeaderBuilder::udp(&mut self.layer4, src_ip, src_port, dst_ip, dst_port, 0);
-        HeaderBuilder::ip(&mut self.ip, 28, 17, src_ip, dst_ip);
-        HeaderBuilder::ether(&mut self.ether, src_mac, dst_mac);
+        HeaderBuilder::udp(&mut self.buffer[34..42], src_ip, src_port, dst_ip, dst_port, 0);
+        HeaderBuilder::ip(&mut self.buffer[14..34], 28, 17, src_ip, dst_ip);
+        HeaderBuilder::ether(&mut self.buffer[..14], src_mac, dst_mac);
 
-        self.packet[..14].copy_from_slice(&self.ether);
-        self.packet[14..34].copy_from_slice(&self.ip);
-        self.packet[34..42].copy_from_slice(&self.layer4[..8]);
-        &self.packet[..42]
+        &self.buffer[..42]
     }
 
 
@@ -171,14 +149,11 @@ impl PacketBuilder {
         dst_ip:  Ipv4Addr,
         ) -> &[u8]
     {
-        HeaderBuilder::icmp(&mut self.layer4);
-        HeaderBuilder::ip(&mut self.ip, 28, 1, src_ip, dst_ip);
-        HeaderBuilder::ether(&mut self.ether, src_mac, dst_mac);
+        HeaderBuilder::icmp(&mut self.buffer[34..42]);
+        HeaderBuilder::ip(&mut self.buffer[14..34], 28, 1, src_ip, dst_ip);
+        HeaderBuilder::ether(&mut self.buffer[..14], src_mac, dst_mac);
 
-        self.packet[..14].copy_from_slice(&self.ether);
-        self.packet[14..34].copy_from_slice(&self.ip);
-        self.packet[34..42].copy_from_slice(&self.layer4[..8]);
-        &self.packet[..42]
+        &self.buffer[..42]
     }
 
 
@@ -190,12 +165,12 @@ impl PacketBuilder {
         dst_mac: [u8; 6]
         ) -> &[u8]
     {
-        HeaderBuilder::auth_802_11(&mut self.packet, src_mac, dst_mac);
+        HeaderBuilder::auth_802_11(&mut self.buffer, src_mac, dst_mac);
 
-        self.packet[24..26].copy_from_slice(&0u16.to_le_bytes());
-        self.packet[26..28].copy_from_slice(&1u16.to_le_bytes());
-        self.packet[28..30].copy_from_slice(&0u16.to_le_bytes());
-        &self.packet[..30]
+        self.buffer[24..26].copy_from_slice(&0u16.to_le_bytes());
+        self.buffer[26..28].copy_from_slice(&1u16.to_le_bytes());
+        self.buffer[28..30].copy_from_slice(&0u16.to_le_bytes());
+        &self.buffer[..30]
     }
 
 }

--- a/src/pkt_builder/pkt_builder.rs
+++ b/src/pkt_builder/pkt_builder.rs
@@ -8,7 +8,6 @@ pub struct PacketBuilder {
 }
 
 
-
 impl PacketBuilder {
 
     pub fn new() -> Self {


### PR DESCRIPTION
This PR introduces two major improvements to our networking toolkit:

### New TCP SYN Flooder functionality:
The SYN flooder now supports both spoofed and fixed MAC/IP addresses, providing greater flexibility for network testing and simulation scenarios.

### Optimized PacketBuilder performance:
Previously, packet construction used four separate buffers (Ethernet, IP, transport layer, and the final packet buffer). Headers were built individually and then copied into the final packet buffer. Now, all headers are constructed directly into the final packet buffer within specific byte ranges, eliminating redundant memory copies and reducing packet creation time.

### Key Benefits:
- Reduced latency: Fewer memory operations during packet assembly.
- Cleaner memory usage: Single-buffer approach minimizes allocations.
- Extended testing capability: The SYN flooder supports customizable addressing for realistic load testing.

### Technical Details:
- The PacketBuilder now manipulates designated ranges in the packet buffer for each header (Ethernet, IP, TCP/UDP/ICMP).
- The SYN flooder integrates seamlessly with the updated builder, using the same efficient construction method.
- Backward compatibility is maintained for existing packet types.