### PR TITLE
Refactor Command System with Centralized Registry and Engine Trait

### DIFF
--- a/src/engines/auth_flood/auth_flood.rs
+++ b/src/engines/auth_flood/auth_flood.rs
@@ -95,3 +95,17 @@ impl AuthenticationFlooder {
     }
 
 }
+
+
+
+impl crate::EngineTrait for AuthenticationFlooder {
+    type Args = AuthArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        AuthenticationFlooder::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}

--- a/src/engines/banner_grab/banner_grab.rs
+++ b/src/engines/banner_grab/banner_grab.rs
@@ -197,3 +197,18 @@ impl BannerGrabber {
         }
     }
 }
+
+
+
+
+impl crate::EngineTrait for BannerGrabber {
+    type Args = BannerArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        BannerGrabber::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}

--- a/src/engines/flood/flood.rs
+++ b/src/engines/flood/flood.rs
@@ -14,6 +14,11 @@ pub struct PacketFlooder {
 }
 
 
+struct PktTools {
+    builder: PacketBuilder,
+    socket:  Layer2RawSocket
+}
+
 
 impl PacketFlooder {
 
@@ -148,7 +153,14 @@ impl PacketFlooder {
 
 
 
-struct PktTools {
-    builder: PacketBuilder,
-    socket:  Layer2RawSocket
+impl crate::EngineTrait for PacketFlooder {
+    type Args = FloodArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        PacketFlooder::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
 }

--- a/src/engines/flood_dns/dns_flood.rs
+++ b/src/engines/flood_dns/dns_flood.rs
@@ -214,3 +214,17 @@ impl DnsFlooder {
     }
 
 }
+
+
+
+impl crate::EngineTrait for DnsFlooder {
+    type Args = DnsArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        DnsFlooder::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}

--- a/src/engines/flood_ping/flood_ping.rs
+++ b/src/engines/flood_ping/flood_ping.rs
@@ -119,3 +119,17 @@ impl PingFlooder {
     }
 
 }
+
+
+
+impl crate::EngineTrait for PingFlooder {
+    type Args = PingArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        PingFlooder::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}

--- a/src/engines/flood_tcp/tcp_flood.rs
+++ b/src/engines/flood_tcp/tcp_flood.rs
@@ -147,3 +147,17 @@ impl PacketData {
         }
     }
 }
+
+
+
+impl crate::EngineTrait for TcpFlooder {
+    type Args = TcpArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        TcpFlooder::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}

--- a/src/engines/net_info/net_info.rs
+++ b/src/engines/net_info/net_info.rs
@@ -1,5 +1,6 @@
 use std::{ fs, path::Path };
 use crate::iface::IfaceInfo;
+use crate::engines::NetInfoArgs;
 
 
 
@@ -21,7 +22,7 @@ pub struct NetworkInfo {
 
 impl NetworkInfo {
 
-    pub fn new() -> Self {
+    pub fn new(_args: NetInfoArgs) -> Self {
         Self { ..Default::default() }
     }
 
@@ -229,4 +230,18 @@ impl NetworkInfo {
         println!("")
     }
 
+}
+
+
+
+impl crate::EngineTrait for NetworkInfo {
+    type Args = NetInfoArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        NetworkInfo::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
 }

--- a/src/engines/netmap/netmap.rs
+++ b/src/engines/netmap/netmap.rs
@@ -304,3 +304,17 @@ impl NetworkMapper {
     }
 
 }
+
+
+
+impl crate::EngineTrait for NetworkMapper {
+    type Args = NetMapArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        NetworkMapper::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}

--- a/src/engines/portscan/portscan.rs
+++ b/src/engines/portscan/portscan.rs
@@ -235,3 +235,17 @@ impl PortScanner {
     }
 
 }
+
+
+
+impl crate::EngineTrait for PortScanner {
+    type Args = PortScanArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        PortScanner::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}

--- a/src/engines/wifi_map/wifi_map.rs
+++ b/src/engines/wifi_map/wifi_map.rs
@@ -167,3 +167,17 @@ impl WifiMapper {
     }
 
 }
+
+
+
+impl crate::EngineTrait for WifiMapper {
+    type Args = WmapArgs;
+    
+    fn new(args: Self::Args) -> Self {
+        WifiMapper::new(args)
+    }
+    
+    fn execute(&mut self) {
+        self.execute();
+    }
+}


### PR DESCRIPTION
This PR introduces a major architectural refactoring of the command execution system, replacing the previous large match statement with a centralized registry and a common EngineTrait interface. This improves code organization, maintainability, and extensibility.

### Core Changes:
- Centralized Command Registry: Created a single source of truth for all commands in get_command_registry() that maps command names to their execution logic
- Generic Execution Pattern: Implemented a reusable execute() function that handles the common pattern: parse arguments → create engine → execute
- EngineTrait Interface: Introduced a trait that all engines must implement, ensuring consistent API across different modules