### PR TITLE
Replace external iw command with native C function for wireless channel switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 name = "offscan"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "clap",
  "libc",
  "pcap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "offscan"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 
 [profile.release]
@@ -9,7 +10,11 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 debug = false
-strip = "symbols"    
+strip = "symbols"
+
+
+[build-dependencies]
+cc = "1.0"
 
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ You can find them listed in the [Cargo.toml](https://github.com/olivercalazans/o
 >
 > - A C compiler and linker (`build-essential` has everyting) — required to build and link Rust binaries.
 > - `libpcap-dev` — required for network packet capture.
-> - `iw` command — required for wireless interface controll.
+> - `libnl-3-dev` and `libnl-genl-3-dev` — required for wireless interface controll.
 >
 > ``` bash
-> sudo apt install build-essential libpcap-dev iw
+> sudo apt install build-essential libpcap-dev libnl-3-dev libnl-genl-3-dev
 > ```
 >   
 > Make sure these are installed before building.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ You can find them listed in the [Cargo.toml](https://github.com/olivercalazans/o
 >
 > - A C compiler and linker (`build-essential` has everyting) — required to build and link Rust binaries.
 > - `libpcap-dev` — required for network packet capture.
-> - `iw` command — required for wireless interface controll.
+> - `libnl-3-dev` and `libnl-genl-3-dev` — required for wireless interface controll.
 >
 > ``` bash
-> sudo apt install build-essential libpcap-dev iw
+> sudo apt install build-essential libpcap-dev libnl-3-dev libnl-genl-3-dev
 > ```
 >   
 > Make sure these are installed before building.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    println!("cargo:rerun-if-changed=c_src/set_wifi_channel.c");
+    
+    cc::Build::new()
+        .file("c_src/set_wifi_channel.c")
+        .include("/usr/include/libnl3")
+        .flag("-I/usr/include/libnl3")
+        .compile("wifichannel");
+    
+    println!("cargo:rustc-link-lib=nl-3");
+    println!("cargo:rustc-link-lib=nl-genl-3");
+}

--- a/c_src/set_wifi_channel.c
+++ b/c_src/set_wifi_channel.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <net/if.h>
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+#include <linux/nl80211.h>
+
+
+
+int set_wifi_channel(const char *interface_name, int channel) {
+    struct nl_sock *sock = NULL;
+    struct nl_cb *cb     = NULL;
+    int ifindex          = 0;
+    int err              = 0;
+    int nl80211_id;
+
+    sock = nl_socket_alloc();
+    if (!sock) {
+        fprintf(stderr, "Failed to allocate netlink socket\n");
+        return -1;
+    }
+
+    if (genl_connect(sock)) {
+        fprintf(stderr, "Failed to connect to generic netlink\n");
+        nl_socket_free(sock);
+        return -1;
+    }
+
+    nl80211_id = genl_ctrl_resolve(sock, "nl80211");
+    if (nl80211_id < 0) {
+        fprintf(stderr, "nl80211 not found\n");
+        nl_socket_free(sock);
+        return -1;
+    }
+
+    ifindex = if_nametoindex(interface_name);
+    if (ifindex == 0) {
+        fprintf(stderr, "Interface %s not found\n", interface_name);
+        nl_socket_free(sock);
+        return -1;
+    }
+
+    cb = nl_cb_alloc(NL_CB_DEFAULT);
+    if (!cb) {
+        fprintf(stderr, "Failed to allocate netlink callback\n");
+        nl_socket_free(sock);
+        return -1;
+    }
+
+    struct nl_msg *msg = nlmsg_alloc();
+    if (!msg) {
+        fprintf(stderr, "Failed to allocate netlink message\n");
+        nl_cb_put(cb);
+        nl_socket_free(sock);
+        return -1;
+    }
+
+    genlmsg_put(msg, 0, 0, nl80211_id, 0, 0, NL80211_CMD_SET_CHANNEL, 0);
+
+    nla_put_u32(msg, NL80211_ATTR_IFINDEX, ifindex);
+    nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, 2407 + channel * 5);
+    nla_put_u32(msg, NL80211_ATTR_CHANNEL_WIDTH, NL80211_CHAN_WIDTH_20_NOHT);
+    nla_put_u32(msg, NL80211_ATTR_WIPHY_CHANNEL_TYPE, NL80211_CHAN_NO_HT);
+
+    err = nl_send_auto(sock, msg);
+    if (err < 0) {
+        fprintf(stderr, "Failed to send netlink message: %d\n", err);
+        nlmsg_free(msg);
+        nl_cb_put(cb);
+        nl_socket_free(sock);
+        return -1;
+    }
+
+    err = nl_recvmsgs(sock, cb);
+    if (err < 0) {
+        fprintf(stderr, "Failed to receive netlink message: %d\n", err);
+    }
+
+    nlmsg_free(msg);
+    nl_cb_put(cb);
+    nl_socket_free(sock);
+
+    return err;
+}

--- a/c_src/set_wifi_channel.h
+++ b/c_src/set_wifi_channel.h
@@ -1,0 +1,14 @@
+#ifndef WIFI_CHANNEL_H
+#define WIFI_CHANNEL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int set_wifi_channel(const char *interface_name, int channel);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/engines/wifi_map/wifi_map.rs
+++ b/src/engines/wifi_map/wifi_map.rs
@@ -115,21 +115,12 @@ impl WifiMapper {
 
     fn display_header(max_len: usize) {
         println!("\n{:<width$}  {:<17}  {}", "SSID", "MAC", "Channel", width = max_len);
-        Self::display_line(max_len);
-    }
-
-
-    
-    fn display_line(max_len: usize) {
         println!("{}  {}  {}", "-".repeat(max_len), "-".repeat(17), "-".repeat(7));
     }
 
 
-
     fn display_wifi_info(name: &str, info: &Info, max_len: usize) {
         let macs: Vec<&String> = info.macs.iter().collect();
-
-        Self::display_line(max_len);
         
         println!("{:<width$}  {}  {}",
                  name, 

--- a/src/iface/iface_manager.rs
+++ b/src/iface/iface_manager.rs
@@ -1,5 +1,10 @@
-use std::process::{Command, Stdio};
+use std::ffi::CString;
 
+
+
+unsafe extern "C" {
+    fn set_wifi_channel(interface_name: *const libc::c_char, channel: libc::c_int) -> libc::c_int;
+}
 
 
 pub struct InterfaceManager;
@@ -8,14 +13,14 @@ pub struct InterfaceManager;
 impl InterfaceManager {
 
     pub fn set_channel(iface: &str, channel: u32) -> bool {
-        let output = Command::new("sudo")
-            .args(&["iw", "dev", iface, "set", "channel", &channel.to_string()])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
+        let c_iface   = CString::new(iface).expect("CString::new failed");
+        let c_channel = channel as i32;
 
-        if output.is_err() {
-            return false;
+        unsafe {
+            let result = set_wifi_channel(c_iface.as_ptr(), c_channel);
+            if result != 0 {
+                return false;
+            }
         }
 
         true


### PR DESCRIPTION
This PR replaces the previous method of changing the wireless network channel, which relied on calling the external iw command via shell, with a dedicated C function that interacts directly with the kernel via Netlink.

### Changes
- Added a native C function to handle wireless channel configuration.
- Removed the dependency on the external iw tool and shell command calls.
- Integrated the C code directly into the Rust binary, reducing external runtime dependencies.

### Benefits
- Reduced external dependencies: The final binary no longer requires the iw command to be available in the system environment.
- Improved efficiency: Direct kernel interaction via Netlink is more efficient than spawning a shell process.
- Self-contained binary: The channel-switching functionality is now embedded within the application itself.

### New Build Dependencies
- To compile the project, the following development libraries are now required:
    - libnl-3-dev
    - libnl-genl-3-dev
- These are used by the C function to communicate with the kernel’s wireless networking subsystem