### PR TITLE
Add C module for OS-driven WiFi scanning and refactor WifiMapper

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,21 @@
 fn main() {
     println!("cargo:rerun-if-changed=c_src/set_wifi_channel.c");
-    
+    println!("cargo:rerun-if-changed=c_src/wifi_scan.c");
+    println!("cargo:rerun-if-changed=c_src/wifi_scan.h");
+
+    let libnl_include = "/usr/include/libnl3";
+
     cc::Build::new()
         .file("c_src/set_wifi_channel.c")
-        .include("/usr/include/libnl3")
-        .flag("-I/usr/include/libnl3")
+        .include(libnl_include)
         .compile("wifichannel");
-    
+
+    cc::Build::new()
+        .file("c_src/wifi_scan.c")
+        .include("c_src")
+        .include(libnl_include)
+        .compile("wifiscan");
+
     println!("cargo:rustc-link-lib=nl-3");
     println!("cargo:rustc-link-lib=nl-genl-3");
 }

--- a/c_src/wifi_scan.c
+++ b/c_src/wifi_scan.c
@@ -1,0 +1,187 @@
+#include "wifi_scan.h"
+
+#include <netlink/netlink.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+#include <netlink/msg.h>
+#include <netlink/attr.h>
+
+#include <linux/nl80211.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <net/if.h>
+
+#define MAX_NETWORKS 256
+
+static wifi_network_t *results = NULL;
+static int result_count        = 0;
+
+
+static int scan_dump_cb(struct nl_msg *msg, void *arg) {
+    (void)arg;
+
+    struct nlattr *tb[NL80211_ATTR_MAX + 1];
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+
+    nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL);
+
+    if (!tb[NL80211_ATTR_BSS])
+        return NL_SKIP;
+
+    struct nlattr *bss[NL80211_BSS_MAX + 1];
+    nla_parse_nested(bss, NL80211_BSS_MAX, tb[NL80211_ATTR_BSS], NULL);
+
+    if (!bss[NL80211_BSS_BSSID] || !bss[NL80211_BSS_INFORMATION_ELEMENTS])
+        return NL_SKIP;
+
+    if (result_count >= MAX_NETWORKS)
+        return NL_SKIP;
+
+    wifi_network_t *net = &results[result_count++];
+
+    memcpy(net->bssid, nla_data(bss[NL80211_BSS_BSSID]), 6);
+
+    net->frequency = bss[NL80211_BSS_FREQUENCY]
+                     ? nla_get_u32(bss[NL80211_BSS_FREQUENCY])
+                     : 0;
+
+    memset(net->ssid, 0, sizeof(net->ssid));
+
+    uint8_t *ie = nla_data(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
+    int ie_len  = nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
+
+    for (int i = 0; i + 1 < ie_len; ) {
+        uint8_t id  = ie[i];
+        uint8_t len = ie[i + 1];
+
+        if (id == 0 && len <= 32) {
+            memcpy(net->ssid, &ie[i + 2], len);
+            net->ssid[len] = '\0';
+            break;
+        }
+
+        i += 2 + len;
+    }
+
+    return NL_OK;
+}
+
+
+
+static int scan_event_cb(struct nl_msg *msg, void *arg) {
+    (void)arg;
+
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+
+    if (gnlh->cmd == NL80211_CMD_NEW_SCAN_RESULTS ||
+        gnlh->cmd == NL80211_CMD_SCAN_ABORTED) {
+        return NL_STOP;
+    }
+
+    return NL_OK;
+}
+
+
+
+int scan_wifi(
+    const char *ifname, 
+    wifi_network_t **out,
+    int *count
+) {
+
+    struct nl_sock *sock = NULL;
+    int nl80211_id;
+    int ifindex;
+    int err;
+
+    *out   = NULL;
+    *count = 0;
+
+    ifindex = if_nametoindex(ifname);
+    if (ifindex == 0)
+        return -ENODEV;
+
+    sock = nl_socket_alloc();
+    if (!sock)
+        return -ENOMEM;
+
+    nl_socket_set_buffer_size(sock, 8192, 8192);
+
+    if (genl_connect(sock))
+        goto fail;
+
+    nl80211_id = genl_ctrl_resolve(sock, "nl80211");
+    if (nl80211_id < 0)
+        goto fail;
+
+    /* ---------- trigger scan ---------- */
+
+    struct nl_msg *msg = nlmsg_alloc();
+    if (!msg)
+        goto fail;
+
+    genlmsg_put(msg, 0, 0, nl80211_id, 0, 0, NL80211_CMD_TRIGGER_SCAN, 0);
+
+    nla_put_u32(msg, NL80211_ATTR_IFINDEX, ifindex);
+
+    struct nl_msg *ssids = nlmsg_alloc();
+    nla_put(ssids, 1, 0, "");
+
+    nla_put_nested(msg, NL80211_ATTR_SCAN_SSIDS, ssids);
+    nlmsg_free(ssids);
+
+    err = nl_send_auto(sock, msg);
+    nlmsg_free(msg);
+
+    if (err < 0)
+        goto fail;
+
+    nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, scan_event_cb, NULL);
+
+    nl_recvmsgs_default(sock);
+
+    usleep(2000 * 1000);
+
+    /* ---------- dump ---------- */
+
+    results = calloc(MAX_NETWORKS, sizeof(wifi_network_t));
+    if (!results)
+        goto fail;
+
+    result_count = 0;
+
+    msg = nlmsg_alloc();
+    genlmsg_put(msg, 0, 0, nl80211_id, 0, NLM_F_DUMP, NL80211_CMD_GET_SCAN, 0);
+
+    nla_put_u32(msg, NL80211_ATTR_IFINDEX, ifindex);
+
+    nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, scan_dump_cb, NULL);
+
+    nl_send_auto(sock, msg);
+    nlmsg_free(msg);
+
+    nl_recvmsgs_default(sock);
+
+    nl_socket_free(sock);
+
+    *out   = results;
+    *count = result_count;
+    return 0;
+
+fail:
+    if (sock)
+        nl_socket_free(sock);
+    if (results) {
+        free(results);
+        results = NULL;
+    }
+    return -1;
+}
+
+
+
+void free_scan_results(wifi_network_t *ptr) {
+    free(ptr);
+}

--- a/c_src/wifi_scan.h
+++ b/c_src/wifi_scan.h
@@ -1,0 +1,25 @@
+// wifi_scan.h
+#ifndef WIFI_SCAN_H
+#define WIFI_SCAN_H
+
+#include <stdint.h>
+
+#define MAX_SSID_LEN 32
+
+typedef struct {
+    uint8_t  bssid[6];
+    char     ssid[MAX_SSID_LEN + 1];
+    uint32_t frequency;
+} wifi_network_t;
+
+
+int scan_wifi(
+    const char *ifname,
+    wifi_network_t **results,
+    int *count
+);
+
+
+void free_scan_results(wifi_network_t *results);
+
+#endif

--- a/src/dissectors/beacon_dissector.rs
+++ b/src/dissectors/beacon_dissector.rs
@@ -1,3 +1,6 @@
+use crate::utils::mac_u8_to_string;
+
+
 pub struct BeaconDissector;
 
 
@@ -133,11 +136,7 @@ impl BeaconDissector {
         }
 
         let bssid_bytes = &frame[16..22];
-        format!(
-            "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-            bssid_bytes[0], bssid_bytes[1], bssid_bytes[2],
-            bssid_bytes[3], bssid_bytes[4], bssid_bytes[5]
-        )
+        mac_u8_to_string(bssid_bytes)
     }
 
 

--- a/src/engines/flood_tcp/tcp_flood.rs
+++ b/src/engines/flood_tcp/tcp_flood.rs
@@ -82,7 +82,7 @@ impl TcpFlooder {
     
     fn display_pkt_data(&self) {
         let src_mac = match self.pkt_data.src_mac {
-            Some(mac) => mac_u8_to_string(mac),
+            Some(mac) => mac_u8_to_string(&mac),
             None      => "Random".to_string(),
         };
 
@@ -92,7 +92,7 @@ impl TcpFlooder {
         };
 
         println!("SRC >> MAC: {}  IP: {}", src_mac, src_ip);
-        println!("DST >> MAC: {}  IP: {}", mac_u8_to_string(self.pkt_data.dst_mac), self.pkt_data.dst_ip);
+        println!("DST >> MAC: {}  IP: {}", mac_u8_to_string(&self.pkt_data.dst_mac), self.pkt_data.dst_ip);
         println!("IFACE: {}", self.iface);
     }
 

--- a/src/engines/wifi_map/mod.rs
+++ b/src/engines/wifi_map/mod.rs
@@ -3,3 +3,12 @@ pub use wmap_parser::WmapArgs;
 
 pub mod wifi_map;
 pub use wifi_map::WifiMapper;
+
+pub mod wifi_data;
+pub use wifi_data::WifiData;
+
+pub mod sys_sniff;
+pub use sys_sniff::SysSniff;
+
+pub mod monitor_sniff;
+pub use monitor_sniff::MonitorSniff;

--- a/src/engines/wifi_map/monitor_sniff.rs
+++ b/src/engines/wifi_map/monitor_sniff.rs
@@ -1,0 +1,128 @@
+use std::{thread, time::Duration, collections::BTreeMap};
+use crate::engines::WifiData;
+use crate::dissectors::BeaconDissector;
+use crate::iface::IfaceManager;
+use crate::sniffer::PacketSniffer;
+use crate::utils::inline_display;
+
+
+
+pub struct MonitorSniff<'a> {
+    iface     : String,
+    wifis_buf : &'a mut BTreeMap<String, WifiData>,
+}
+
+
+impl<'a> MonitorSniff<'a> {
+
+    pub fn new(iface: String, wifis_buf: &'a mut BTreeMap<String, WifiData>) -> Self {
+        Self { iface, wifis_buf, }
+    }
+
+
+
+    pub fn execute_monitor_sniff(&mut self) {
+        println!("Sniffing beacons on monitor mode");
+
+        let beacons = self.start_sniffing();
+        self.process_beacons(beacons);
+    }
+
+
+
+    fn start_sniffing(&mut self) -> Vec<Vec<u8>> {
+        let mut sniffer = PacketSniffer::new(
+            self.iface.clone(),
+            "type mgt and subtype beacon".to_string()
+        );
+        
+        sniffer.start();
+        self.sniff_2g_channels();
+        self.sniff_5g_channels();
+        sniffer.stop();
+
+        sniffer.get_packets()
+    }    
+
+
+
+    fn sniff_2g_channels(&self) {
+        const CHANNELS: [i32; 14] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+
+        for channel in CHANNELS {
+            self.set_channel(channel, "2.4");
+        }
+    }
+
+
+
+    fn sniff_5g_channels(&self) {
+        const CHANNELS: [i32; 25] = [
+            36,  40,  44,  48,  52,  56,  60,  64,  100, 104,
+            108, 112, 116, 120, 124, 128, 132, 136, 140, 144,
+            149, 153, 157, 161, 165
+        ];
+
+
+        for channel in CHANNELS {
+            self.set_channel(channel, "5");
+        }
+    }
+
+
+
+    #[inline]
+    fn set_channel(&self, channel: i32, frequency: &str) {
+        let done = IfaceManager::set_channel(&self.iface, channel);
+
+        if !done {
+            println!("\nUneable to set channel {}", channel);
+            return;
+        }
+
+        inline_display(&format!("Sniffing channel {} ({}G)", channel, frequency));
+        thread::sleep(Duration::from_millis(300));
+    }
+
+
+
+    fn process_beacons(&mut self, beacons: Vec<Vec<u8>>) {
+        for b in beacons.into_iter() {
+            if let Some(info) = BeaconDissector::parse_beacon(&b) {
+                let ssid        = info[0].clone();
+                let bssid       = info[1].clone();
+                let channel: u8 = info[2].parse().unwrap_or_else(|_| 0);
+                let frequency   = Self::get_frequency(channel);
+                
+                self.add_info(ssid, bssid, channel, frequency);
+            }
+        }
+    }
+
+
+
+    fn get_frequency(channel: u8) -> String {
+        if channel <= 14 {"2.4".to_string()} else {"5".to_string()}
+    }
+
+
+
+    #[inline]
+    fn add_info(
+        &mut self, 
+        ssid      : String, 
+        bssid     : String, 
+        channel   : u8, 
+        frequency : String
+    ) {
+        self.wifis_buf
+            .entry(ssid)
+            .and_modify(|existing_info| {
+                existing_info.bssids.insert(bssid.clone());
+            })
+            .or_insert_with(|| {
+                WifiData::new(bssid, channel, frequency.to_string())
+            });
+    }
+
+}

--- a/src/engines/wifi_map/wifi_data.rs
+++ b/src/engines/wifi_map/wifi_data.rs
@@ -1,0 +1,23 @@
+use std::collections::HashSet;
+
+
+
+pub struct WifiData {
+    pub bssids    : HashSet<String>,
+    pub channel   : u8,
+    pub frequency : String
+}
+
+
+impl WifiData {
+    pub fn new(
+        bssid     : String, 
+        channel   : u8, 
+        frequency : String
+    ) -> Self {
+        let mut bssids = HashSet::new();
+        bssids.insert(bssid);
+
+        Self { bssids, channel, frequency }
+    }
+}

--- a/src/engines/wifi_map/wifi_map.rs
+++ b/src/engines/wifi_map/wifi_map.rs
@@ -3,52 +3,156 @@ use crate::engines::WmapArgs;
 use crate::dissectors::BeaconDissector;
 use crate::iface::IfaceManager;
 use crate::sniffer::PacketSniffer;
-use crate::utils::inline_display;
+use crate::utils::{inline_display, mac_u8_to_string, abort};
 
+
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WifiInfo {
+    bssid     : [u8; 6],
+    ssid      : [i8; 33],
+    frequency : u32,
+}
+
+
+unsafe extern "C" {
+    fn scan_wifi(
+        ifname  : *const i8,
+        results : *mut *mut WifiInfo,
+        count   : *mut i32,
+    ) -> i32;
+
+    fn free_scan_results(results: *mut WifiInfo);
+}
 
 
 
 pub struct WifiMapper {
-    args        : WmapArgs,
-    raw_beacons : Vec<Vec<u8>>,
-    wifis       : BTreeMap<String, Info>,
+    args  : WmapArgs,
+    wifis : BTreeMap<String, Info>,
 }
 
 
 impl WifiMapper {
     
     pub fn new(args: WmapArgs) -> Self {
-        Self {
-            raw_beacons : Vec::new(),
-            wifis       : BTreeMap::new(),
-            args,
-        }
+        Self { args, wifis : BTreeMap::new(), }
     }
 
 
 
     pub fn execute(&mut self) {
-        self.get_beacons();
-        self.process_beacons();
+        match self.args.monitor {
+            true  => self.sniff_beacons(),
+            false => self.get_info_from_sys(),
+        }
+
         self.display_results();
+    }
+
+
+
+    fn get_info_from_sys(&mut self) {
+        println!("Sniffing beacons on monitor mode");
+
+        let sys_info = self.call_c_module();
+        self.process_info(sys_info);
+    }
+
+
+
+    fn call_c_module(&mut self) -> Vec<WifiInfo>{
+        unsafe {
+            let iface = std::ffi::CString::new(self.args.iface.clone()).unwrap();
+
+            let mut ptr: *mut WifiInfo = std::ptr::null_mut();
+            let mut count: i32 = 0;
+
+            let ret = scan_wifi(
+                iface.as_ptr(),
+                &mut ptr,
+                &mut count,
+            );
+
+            if ret != 0 {
+                abort(format!("Erro no scan: {}", ret));
+            }
+
+            let slice    = std::slice::from_raw_parts(ptr, count as usize);
+            let sys_info = slice.iter().copied().map(Into::into).collect();
+
+            free_scan_results(ptr);
+
+            sys_info
+        }
+    }
+
+
+
+    fn process_info(&mut self, sys_info: Vec<WifiInfo>) {
+        for info in sys_info.into_iter() {
+            let ssid      = Self::ssid_to_string(&info.ssid);
+            let bssid     = mac_u8_to_string(&info.bssid);
+            let channel   = Self::freq_to_channel(info.frequency);
+            let frequency = Self::get_frequency(channel);
+
+            self.add_info(ssid, bssid, channel, frequency)
+        }
+    }
+
+
+
+    fn ssid_to_string(ssid: &[i8]) -> String {
+        let bytes: Vec<u8> = ssid
+            .iter()
+            .take_while(|&&b| b != 0)
+            .map(|&b| b as u8)
+            .collect();
+
+        String::from_utf8_lossy(&bytes).to_string()
+    }
+
+
+
+    fn freq_to_channel(freq: u32) -> u8 {
+        match freq {
+            2412..=2472 => ((freq - 2407) / 5) as u8,
+            2484        => 14,
+            5000..=5900 => ((freq - 5000) / 5) as u8,
+            _           => 0,
+        }
+    }
+
+
+
+    fn get_frequency(channel: u8) -> String {
+        if channel <= 14 {"2.4".to_string()} else {"5".to_string()}
     }
     
 
 
-    fn get_beacons(&mut self) {        
+    fn sniff_beacons(&mut self) {
+        println!("Sniffing beacons on monitor mode");
+
+        let beacons = self.start_sniffing();
+        self.process_beacons(beacons);
+    }
+
+
+
+    fn start_sniffing(&mut self) -> Vec<Vec<u8>> {
         let mut sniffer = PacketSniffer::new(
             self.args.iface.clone(),
             "type mgt and subtype beacon".to_string()
         );
-
-        println!("Sniffing beacons");
         
         sniffer.start();
         self.sniff_2g_channels();
         self.sniff_5g_channels();
         sniffer.stop();
 
-        self.raw_beacons = sniffer.get_packets();
+        sniffer.get_packets()
     }    
 
 
@@ -83,7 +187,7 @@ impl WifiMapper {
         let done = IfaceManager::set_channel(&self.args.iface, channel);
 
         if !done {
-            println!("Uneable to set channel {}", channel);
+            println!("\nUneable to set channel {}", channel);
             return;
         }
 
@@ -93,31 +197,35 @@ impl WifiMapper {
 
 
 
-    fn process_beacons(&mut self) {
-        let beacons = mem::take(&mut self.raw_beacons);
-
+    fn process_beacons(&mut self, beacons: Vec<Vec<u8>>) {
         for b in beacons.into_iter() {
             if let Some(info) = BeaconDissector::parse_beacon(&b) {
-                self.add_info(info);
+                let ssid        = info[0].clone();
+                let bssid       = info[1].clone();
+                let channel: u8 = info[2].parse().unwrap_or_else(|_| 0);
+                let frequency   = Self::get_frequency(channel);
+                
+                self.add_info(ssid, bssid, channel, frequency);
             }
         }
     }
 
 
 
-    fn add_info(&mut self, info: Vec<String>) {
-        let ssid         = info[0].clone();
-        let mac          = info[1].clone();
-        let channel: u32 = info[2].parse().unwrap_or_else(|_| 0);
-        let frequency    = if channel <= 14 {"2.4"} else {"5"};
-
+    fn add_info(
+        &mut self, 
+        ssid      : String, 
+        bssid     : String, 
+        channel   : u8, 
+        frequency : String
+    ) {
         self.wifis
             .entry(ssid)
             .and_modify(|existing_info| {
-                existing_info.macs.insert(mac.clone());
+                existing_info.bssids.insert(bssid.clone());
             })
             .or_insert_with(|| {
-                Info::new(mac, channel, frequency.to_string())
+                Info::new(bssid, channel, frequency.to_string())
             });
     }
 
@@ -147,19 +255,19 @@ impl WifiMapper {
 
 
     fn display_wifi_info(name: &str, info: &Info, max_len: usize) {
-        let macs: Vec<&String> = info.macs.iter().collect();
+        let bssids: Vec<&String> = info.bssids.iter().collect();
         
         println!(
             "{:<width$}  {}  {:<7}  {}G",
             name, 
-            macs.first().unwrap_or(&&"N/A".to_string()), 
+            bssids.first().unwrap_or(&&"N/A".to_string()), 
             info.channel,
             info.frequency,
             width = max_len
         );
         
-        for mac in macs.iter().skip(1) {
-            println!("{:<width$}  {}", "", mac, width = max_len);
+        for bssid in bssids.iter().skip(1) {
+            println!("{:<width$}  {}", "", bssid, width = max_len);
         }
     }
 
@@ -183,21 +291,21 @@ impl crate::EngineTrait for WifiMapper {
 
 #[derive(Debug)]
 struct Info {
-    macs      : HashSet<String>,
-    channel   : u32,
+    bssids    : HashSet<String>,
+    channel   : u8,
     frequency : String
 }
 
 
 impl Info {
     fn new(
-        mac       : String, 
-        channel   : u32, 
+        bssid     : String, 
+        channel   : u8, 
         frequency : String
     ) -> Self {
-        let mut macs = HashSet::new();
-        macs.insert(mac);
+        let mut bssids = HashSet::new();
+        bssids.insert(bssid);
 
-        Self { macs, channel, frequency }
+        Self { bssids, channel, frequency }
     }
 }

--- a/src/engines/wifi_map/wifi_map.rs
+++ b/src/engines/wifi_map/wifi_map.rs
@@ -1,36 +1,11 @@
-use std::{thread, time::Duration, collections::{HashSet, BTreeMap}, mem};
-use crate::engines::WmapArgs;
-use crate::dissectors::BeaconDissector;
-use crate::iface::IfaceManager;
-use crate::sniffer::PacketSniffer;
-use crate::utils::{inline_display, mac_u8_to_string, abort};
-
-
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct WifiInfo {
-    bssid     : [u8; 6],
-    ssid      : [i8; 33],
-    frequency : u32,
-}
-
-
-unsafe extern "C" {
-    fn scan_wifi(
-        ifname  : *const i8,
-        results : *mut *mut WifiInfo,
-        count   : *mut i32,
-    ) -> i32;
-
-    fn free_scan_results(results: *mut WifiInfo);
-}
+use std::{collections::BTreeMap, mem};
+use crate::engines::{WmapArgs, WifiData, SysSniff, MonitorSniff};
 
 
 
 pub struct WifiMapper {
     args  : WmapArgs,
-    wifis : BTreeMap<String, Info>,
+    wifis : BTreeMap<String, WifiData>,
 }
 
 
@@ -44,8 +19,8 @@ impl WifiMapper {
 
     pub fn execute(&mut self) {
         match self.args.monitor {
-            true  => self.sniff_beacons(),
-            false => self.get_info_from_sys(),
+            true  => self.monitor_sniff(),
+            false => self.sys_sniff(),
         }
 
         self.display_results();
@@ -53,185 +28,21 @@ impl WifiMapper {
 
 
 
-    fn get_info_from_sys(&mut self) {
-        println!("Sniffing beacons on monitor mode");
-
-        let sys_info = self.call_c_module();
-        self.process_info(sys_info);
+    fn monitor_sniff(&mut self) {
+        let mut mon_sniff = MonitorSniff::new(self.args.iface.clone(), &mut self.wifis);
+        mon_sniff.execute_monitor_sniff();
     }
 
 
 
-    fn call_c_module(&mut self) -> Vec<WifiInfo>{
-        unsafe {
-            let iface = std::ffi::CString::new(self.args.iface.clone()).unwrap();
-
-            let mut ptr: *mut WifiInfo = std::ptr::null_mut();
-            let mut count: i32 = 0;
-
-            let ret = scan_wifi(
-                iface.as_ptr(),
-                &mut ptr,
-                &mut count,
-            );
-
-            if ret != 0 {
-                abort(format!("Erro no scan: {}", ret));
-            }
-
-            let slice    = std::slice::from_raw_parts(ptr, count as usize);
-            let sys_info = slice.iter().copied().map(Into::into).collect();
-
-            free_scan_results(ptr);
-
-            sys_info
-        }
+    fn sys_sniff(&mut self) {
+        let mut sys_sniff = SysSniff::new(self.args.iface.clone(), &mut self.wifis);
+        sys_sniff.execute_sys_sniff();
     }
 
 
 
-    fn process_info(&mut self, sys_info: Vec<WifiInfo>) {
-        for info in sys_info.into_iter() {
-            let ssid      = Self::ssid_to_string(&info.ssid);
-            let bssid     = mac_u8_to_string(&info.bssid);
-            let channel   = Self::freq_to_channel(info.frequency);
-            let frequency = Self::get_frequency(channel);
-
-            self.add_info(ssid, bssid, channel, frequency)
-        }
-    }
-
-
-
-    fn ssid_to_string(ssid: &[i8]) -> String {
-        let bytes: Vec<u8> = ssid
-            .iter()
-            .take_while(|&&b| b != 0)
-            .map(|&b| b as u8)
-            .collect();
-
-        String::from_utf8_lossy(&bytes).to_string()
-    }
-
-
-
-    fn freq_to_channel(freq: u32) -> u8 {
-        match freq {
-            2412..=2472 => ((freq - 2407) / 5) as u8,
-            2484        => 14,
-            5000..=5900 => ((freq - 5000) / 5) as u8,
-            _           => 0,
-        }
-    }
-
-
-
-    fn get_frequency(channel: u8) -> String {
-        if channel <= 14 {"2.4".to_string()} else {"5".to_string()}
-    }
-    
-
-
-    fn sniff_beacons(&mut self) {
-        println!("Sniffing beacons on monitor mode");
-
-        let beacons = self.start_sniffing();
-        self.process_beacons(beacons);
-    }
-
-
-
-    fn start_sniffing(&mut self) -> Vec<Vec<u8>> {
-        let mut sniffer = PacketSniffer::new(
-            self.args.iface.clone(),
-            "type mgt and subtype beacon".to_string()
-        );
-        
-        sniffer.start();
-        self.sniff_2g_channels();
-        self.sniff_5g_channels();
-        sniffer.stop();
-
-        sniffer.get_packets()
-    }    
-
-
-
-    fn sniff_2g_channels(&self) {
-        const CHANNELS: [i32; 14] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
-
-        for channel in CHANNELS {
-            self.set_channel(channel, "2.4");
-        }
-    }
-
-
-
-    fn sniff_5g_channels(&self) {
-        const CHANNELS: [i32; 25] = [
-            36,  40,  44,  48,  52,  56,  60,  64,  100, 104,
-            108, 112, 116, 120, 124, 128, 132, 136, 140, 144,
-            149, 153, 157, 161, 165
-        ];
-
-
-        for channel in CHANNELS {
-            self.set_channel(channel, "5");
-        }
-    }
-
-
-
-    #[inline]
-    fn set_channel(&self, channel: i32, frequency: &str) {
-        let done = IfaceManager::set_channel(&self.args.iface, channel);
-
-        if !done {
-            println!("\nUneable to set channel {}", channel);
-            return;
-        }
-
-        inline_display(&format!("Sniffing channel {} ({}G)", channel, frequency));
-        thread::sleep(Duration::from_millis(300));
-    }
-
-
-
-    fn process_beacons(&mut self, beacons: Vec<Vec<u8>>) {
-        for b in beacons.into_iter() {
-            if let Some(info) = BeaconDissector::parse_beacon(&b) {
-                let ssid        = info[0].clone();
-                let bssid       = info[1].clone();
-                let channel: u8 = info[2].parse().unwrap_or_else(|_| 0);
-                let frequency   = Self::get_frequency(channel);
-                
-                self.add_info(ssid, bssid, channel, frequency);
-            }
-        }
-    }
-
-
-
-    fn add_info(
-        &mut self, 
-        ssid      : String, 
-        bssid     : String, 
-        channel   : u8, 
-        frequency : String
-    ) {
-        self.wifis
-            .entry(ssid)
-            .and_modify(|existing_info| {
-                existing_info.bssids.insert(bssid.clone());
-            })
-            .or_insert_with(|| {
-                Info::new(bssid, channel, frequency.to_string())
-            });
-    }
-
-
-
-    fn display_results(&mut self) {
+     fn display_results(&mut self) {
         let max_len = self.wifis.keys().map(String::len).max().unwrap_or(4);
         let wifis   = mem::take(&mut self.wifis);
 
@@ -254,20 +65,20 @@ impl WifiMapper {
 
 
 
-    fn display_wifi_info(name: &str, info: &Info, max_len: usize) {
-        let bssids: Vec<&String> = info.bssids.iter().collect();
+    fn display_wifi_info(name: &str, info: &WifiData, max_len: usize) {
+        let macs: Vec<&String> = info.bssids.iter().collect();
         
         println!(
             "{:<width$}  {}  {:<7}  {}G",
             name, 
-            bssids.first().unwrap_or(&&"N/A".to_string()), 
+            macs.first().unwrap_or(&&"N/A".to_string()), 
             info.channel,
             info.frequency,
             width = max_len
         );
         
-        for bssid in bssids.iter().skip(1) {
-            println!("{:<width$}  {}", "", bssid, width = max_len);
+        for mac in macs.iter().skip(1) {
+            println!("{:<width$}  {}", "", mac, width = max_len);
         }
     }
 
@@ -284,28 +95,5 @@ impl crate::EngineTrait for WifiMapper {
     
     fn execute(&mut self) {
         self.execute();
-    }
-}
-
-
-
-#[derive(Debug)]
-struct Info {
-    bssids    : HashSet<String>,
-    channel   : u8,
-    frequency : String
-}
-
-
-impl Info {
-    fn new(
-        bssid     : String, 
-        channel   : u8, 
-        frequency : String
-    ) -> Self {
-        let mut bssids = HashSet::new();
-        bssids.insert(bssid);
-
-        Self { bssids, channel, frequency }
     }
 }

--- a/src/engines/wifi_map/wmap_parser.rs
+++ b/src/engines/wifi_map/wmap_parser.rs
@@ -12,8 +12,8 @@ pub struct WmapArgs {
     pub iface: String,
 
 
-    /// Set a time to wait before close the beacons capture
-    #[arg(short, long, default_value_t = 2)]
-    pub time: u64,
+    /// Sniff beacons from the interface on monitor mode
+    #[arg(short = 'M', long)]
+    pub monitor: bool,
 
 }

--- a/src/generators/ipv4_iter.rs
+++ b/src/generators/ipv4_iter.rs
@@ -105,20 +105,14 @@ impl Ipv4Iter {
 
 
     fn parse_range(data: &mut TempData) -> (u32, u32) {
-        Self::validate_non_empty_range(data);
+        if data.range.is_empty() {
+            abort("Range string cannot be empty");
+        }
 
         if data.range.contains('*') {
             Self::parse_wildcard_range(data)
         } else {
             Self::parse_single_ip_range(data)
-        }
-    }
-
-
-
-    fn validate_non_empty_range(data: &TempData) {
-        if data.range.is_empty() {
-            abort("Range string cannot be empty");
         }
     }
 

--- a/src/utils/format_mac.rs
+++ b/src/utils/format_mac.rs
@@ -1,4 +1,4 @@
-pub fn mac_u8_to_string(mac: [u8; 6]) -> String {
+pub fn mac_u8_to_string(mac: &[u8]) -> String {
     format!(
         "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
         mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]


### PR DESCRIPTION
This PR introduces a new C module (`SysSniff`) that leverages the operating system's native WiFi management to trigger a scan and retrieve nearby network information without requiring monitor mode. The module fetches SSID, BSSID, and frequency data directly from the OS, shifting the low-level work to the kernel and simplifying passive network discovery.

The previous monitor-mode sniffing approach remains fully functional and is now organized into a separate submodule (`MonitorSniff`). It is activated when the `-M` or `--monitor` flag is used.

### Key changes:
- Added `SysSniff` submodule for OS-mediated WiFi scanning (default behavior).
- Retained `MonitorSniff` submodule for beacon sniffing via monitor mode (used with `-M`/`--monitor`).
- Refactored `WifiMapper` into a controller interface that manages both submodules and presents captured data.
- Improved code organization, readability, and separation of concerns.

### Benefits:
- Faster, less intrusive scanning by default.
- No need for monitor mode in standard operation.
- Cleaner architecture with dedicated submodules for each scanning method.

The change maintains backward compatibility and provides a more efficient default scanning method while preserving full monitor-mode capability when required.