### PR TITLE
Add sec type in sys sniffer

### DIFF
--- a/c_src/wifi_scan.h
+++ b/c_src/wifi_scan.h
@@ -1,4 +1,3 @@
-// wifi_scan.h
 #ifndef WIFI_SCAN_H
 #define WIFI_SCAN_H
 
@@ -10,6 +9,7 @@ typedef struct {
     uint8_t  bssid[6];
     char     ssid[MAX_SSID_LEN + 1];
     uint32_t frequency;
+    char     security[16];
 } wifi_network_t;
 
 


### PR DESCRIPTION
This PR adds refactored code to the Wifi Mapper. SysSniff now obtains and displays the security type for each Wi-Fi network.