### PR TITLE
Add interface mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
       <ul style="list-style-type: none; padding-left: 0; margin: 0;">
         <li><strong><em>Deauthentication Attack</em></strong></li>
         <li><strong><em>Beacon Flooding</em></strong></li>
-        <li><strong><em>Ping Flooding</em></strong></li>
-        <li><strong><em>TCP Flooding</em></strong></li>
       </ul>
     </td>
     <td style="width:50%; vertical-align: top; padding: 15px; background-color: #0D1117; color: #C9D1D9; border-radius: 8px; height: 150px;">

--- a/engines/beacon/arg_parser.go
+++ b/engines/beacon/arg_parser.go
@@ -62,7 +62,7 @@ func parseArgs(argList []string) *bcFloodArgs {
 
 	bcArgs := &bcFloodArgs{
 		Ssid:    opts.Ssid,
-		Iface:   conv.MustGetIface(opts.Iface),
+		Iface:   conv.MustStrToIface(opts.Iface),
 		Channel: opts.Channel,
 	}
 

--- a/engines/beacon/beacon_flood.go
+++ b/engines/beacon/beacon_flood.go
@@ -37,7 +37,7 @@ func Run(args []string) {
 
 
 
-type BeaconFlood struct {
+type beaconFlood struct {
     channel uint8
     ssid    string
     bcSent  int
@@ -47,12 +47,12 @@ type BeaconFlood struct {
 
 
 
-func newBeaconFlooder(argList []string) *BeaconFlood {
+func newBeaconFlooder(argList []string) *beaconFlood {
 	bcArgs := parseArgs(argList)
 
     ifconfig.MustSetChannel(bcArgs.Iface, bcArgs.Channel)
 
-    return &BeaconFlood{
+    return &beaconFlood{
         channel: uint8(bcArgs.Channel),
         ssid:    bcArgs.Ssid,
         bcSent:  0,
@@ -63,7 +63,7 @@ func newBeaconFlooder(argList []string) *BeaconFlood {
 
 
 
-func (b *BeaconFlood) execute() {
+func (b *beaconFlood) execute() {
     ctx     := utils.SignalContext()
     randGen := generators.NewRandomValues()
     start   := time.Now()
@@ -89,7 +89,7 @@ func (b *BeaconFlood) execute() {
 
 
 
-func (b *BeaconFlood) sendQuartet(bssid net.HardwareAddr, ssid string, seq uint16) {
+func (b *beaconFlood) sendQuartet(bssid net.HardwareAddr, ssid string, seq uint16) {
     b.sendBeacon(bssid, ssid, seq, "open")
     b.sendBeacon(bssid, ssid, seq+1, "wpa")
     b.sendBeacon(bssid, ssid, seq+2, "wpa2")
@@ -98,7 +98,7 @@ func (b *BeaconFlood) sendQuartet(bssid net.HardwareAddr, ssid string, seq uint1
 
 
 
-func (b *BeaconFlood) sendBeacon(bssid net.HardwareAddr, ssid string, seq uint16, sec string) {
+func (b *beaconFlood) sendBeacon(bssid net.HardwareAddr, ssid string, seq uint16, sec string) {
     beacon := b.builder.Beacon(bssid, ssid, seq, b.channel, sec)
     b.socket.Send(beacon)
     b.bcSent++

--- a/engines/deauth/arg_parser.go
+++ b/engines/deauth/arg_parser.go
@@ -66,7 +66,7 @@ func ParseArgs(argList []string) *deauthArgs {
     deauthArgs := &deauthArgs{
         Delay:     opts.Delay,
         Channel:   opts.Channel,
-        Iface:     conv.MustGetIface(opts.Iface),
+        Iface:     conv.MustStrToIface(opts.Iface),
         Bssid:     conv.MustStrToMac(opts.Bssid),
         TargetMac: conv.MustStrToMac(opts.TargetMac),
     }

--- a/engines/deauth/arg_parser.go
+++ b/engines/deauth/arg_parser.go
@@ -29,7 +29,7 @@ import (
 
 
 
-type DeauthArgs struct {
+type deauthArgs struct {
     Iface     *net.Interface 
     TargetMac  net.HardwareAddr
     Bssid      net.HardwareAddr
@@ -48,7 +48,7 @@ type Args struct {
 
 
 
-func ParseArgs(argList []string) *DeauthArgs {
+func ParseArgs(argList []string) *deauthArgs {
     var opts Args
     
     parser := flags.NewParser(&opts, flags.HelpFlag)
@@ -63,7 +63,7 @@ func ParseArgs(argList []string) *DeauthArgs {
         utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
 
-    deauthArgs := &DeauthArgs{
+    deauthArgs := &deauthArgs{
         Delay:     opts.Delay,
         Channel:   opts.Channel,
         Iface:     conv.MustGetIface(opts.Iface),

--- a/engines/deauth/deauth.go
+++ b/engines/deauth/deauth.go
@@ -36,7 +36,7 @@ func Run(args []string) {
 
 
 
-type Deauthentication struct {
+type deauthentication struct {
     builder    *frame80211.Deauth
     frmsSent   int
     seqNum     uint16
@@ -48,13 +48,13 @@ type Deauthentication struct {
 
 
 
-func newDeauth(argList []string) *Deauthentication {
+func newDeauth(argList []string) *deauthentication {
     args := ParseArgs(argList)
     
     ifconfig.MustSetChannel(args.Iface, args.Channel)
     displayExecInfo(args)
 
-    return &Deauthentication{
+    return &deauthentication{
         builder:   frame80211.NewDeauthFrame(args.Bssid),
         frmsSent:  0,
         seqNum:    1,
@@ -67,7 +67,7 @@ func newDeauth(argList []string) *Deauthentication {
 
 
 
-func displayExecInfo(args *DeauthArgs) {
+func displayExecInfo(args *deauthArgs) {
     fmt.Printf("[*] IFACE...: %s\n", args.Iface.Name)
     fmt.Printf("[*] BSSID...: %s\n", args.Bssid.String())
     fmt.Printf("[*] TARGET..: %s\n", args.TargetMac.String())
@@ -76,7 +76,7 @@ func displayExecInfo(args *DeauthArgs) {
 
 
 
-func (d *Deauthentication) execute() {
+func (d *deauthentication) execute() {
     ctx := utils.SignalContext()
 
     fmt.Println("[+] Sending frames. Press Ctrl + C to stop")
@@ -106,7 +106,7 @@ func (d *Deauthentication) execute() {
 
 
 
-func (d *Deauthentication) sendFrame(srcMac, dstMac net.HardwareAddr) {
+func (d *deauthentication) sendFrame(srcMac, dstMac net.HardwareAddr) {
     frame := d.builder.Frame(dstMac, srcMac, d.seqNum)
     d.socket.Send(frame)
     
@@ -116,7 +116,7 @@ func (d *Deauthentication) sendFrame(srcMac, dstMac net.HardwareAddr) {
 
 
 
-func (d *Deauthentication) updateSeqNum() {
+func (d *deauthentication) updateSeqNum() {
     if d.seqNum >= 4095 {
         d.seqNum = 0
     }

--- a/engines/hostdisc/arg_parser.go
+++ b/engines/hostdisc/arg_parser.go
@@ -27,7 +27,7 @@ import (
 
 
 
-type HostDiscArgs struct {
+type hostDiscArgs struct {
     Delay  string  `short:"d" long:"delay" default:"0.03" description:"Add a delay between packet transmissions."`
     Iface *string  `short:"i" long:"iface" description:"Network interface to send packets (default: system default)"`
     Range *string  `short:"r" long:"range" description:"IP range to scan"`
@@ -38,8 +38,8 @@ type HostDiscArgs struct {
 
 
 
-func ParseNetMapArgs(args []string) *HostDiscArgs {
-    var opts HostDiscArgs
+func ParseNetMapArgs(args []string) *hostDiscArgs {
+    var opts hostDiscArgs
     
 	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)

--- a/engines/hostdisc/hd_pkt_proc.go
+++ b/engines/hostdisc/hd_pkt_proc.go
@@ -29,7 +29,7 @@ import (
 
 
 
-func (hd *HostDiscovery) startPacketProcessor() {
+func (hd *hostDiscovery) startPacketProcessor() {
     hd.sniffer   = pktsniffer.NewSniffer(hd.iface, hd.getBpfFilter(), false)
     hd.snifferCh = hd.sniffer.Start()
 
@@ -53,7 +53,7 @@ func (hd *HostDiscovery) startPacketProcessor() {
 
 
 
-func (hd *HostDiscovery) getBpfFilter() string {
+func (hd *hostDiscovery) getBpfFilter() string {
     return fmt.Sprintf(
         "(dst host %s and src net %s) or (arp[6:2] = 2)", 
         hd.myIP.String(),
@@ -63,7 +63,7 @@ func (hd *HostDiscovery) getBpfFilter() string {
 
 
 
-func (hd *HostDiscovery) cidrForBPFFilter() string {
+func (hd *hostDiscovery) cidrForBPFFilter() string {
     xor := hd.ips.StartU32 ^ hd.ips.EndU32
     var leadingZeros int
     
@@ -90,7 +90,7 @@ func (hd *HostDiscovery) cidrForBPFFilter() string {
 
 
 
-func (hd *HostDiscovery) dissectAndUpdate(pkt []byte, tempMap map[[4]byte]hostInfo) {
+func (hd *hostDiscovery) dissectAndUpdate(pkt []byte, tempMap map[[4]byte]hostInfo) {
     dissector := pktdissector.NewPacketDissector()
     dissector.UpdatePkt(pkt)
 
@@ -114,14 +114,14 @@ func (hd *HostDiscovery) dissectAndUpdate(pkt []byte, tempMap map[[4]byte]hostIn
 
 
 
-func (hd *HostDiscovery) isInRange(ip net.IP) bool {
+func (hd *hostDiscovery) isInRange(ip net.IP) bool {
     ipU32 := conv.IPToU32(ip)
     return ipU32 >= hd.ips.StartU32 && ipU32 <= hd.ips.EndU32
 }
 
 
 
-func (hd *HostDiscovery) stopPacketProcessor() {
+func (hd *hostDiscovery) stopPacketProcessor() {
     hd.sniffer.Stop()
     hd.wgPktProc.Wait()
 }

--- a/engines/hostdisc/hd_pkt_send.go
+++ b/engines/hostdisc/hd_pkt_send.go
@@ -28,7 +28,7 @@ import (
 
 
 
-func (hd *HostDiscovery) createGoroutines() {
+func (hd *hostDiscovery) createGoroutines() {
     if hd.protocols.arp {
         hd.wgSocks.Add(1)
         go hd.sendProbes("arp", *hd.ips)
@@ -55,7 +55,7 @@ func (hd *HostDiscovery) createGoroutines() {
 
 
 
-func (hd *HostDiscovery) sendProbes(proto string, ips generators.Ipv4Iter) {
+func (hd *hostDiscovery) sendProbes(proto string, ips generators.Ipv4Iter) {
     defer hd.wgSocks.Done()
 
 	switch proto {
@@ -70,7 +70,7 @@ func (hd *HostDiscovery) sendProbes(proto string, ips generators.Ipv4Iter) {
 
 
 
-func (hd *HostDiscovery) sendArpProbes() {
+func (hd *hostDiscovery) sendArpProbes() {
     ips    := *hd.ips
     delays := generators.NewDelayIter(hd.delay, int(ips.Total()))
     socket := sockets.NewL3Socket(hd.iface)
@@ -96,7 +96,7 @@ func (hd *HostDiscovery) sendArpProbes() {
 
 
 
-func (hd *HostDiscovery) sendIcmpProbes() {
+func (hd *hostDiscovery) sendIcmpProbes() {
     ips      := *hd.ips
     delays   := generators.NewDelayIter(hd.delay, int(ips.Total()))
     socket   := sockets.NewL3Socket(hd.iface)
@@ -119,7 +119,7 @@ func (hd *HostDiscovery) sendIcmpProbes() {
 
 
 
-func (hd *HostDiscovery) sendTcpProbes() {
+func (hd *hostDiscovery) sendTcpProbes() {
     ips      := *hd.ips
     delays   := generators.NewDelayIter(hd.delay, int(ips.Total()))
     socket   := sockets.NewL3Socket(hd.iface)
@@ -144,7 +144,7 @@ func (hd *HostDiscovery) sendTcpProbes() {
 
 
 
-func (hd *HostDiscovery) sendUdpProbes() {
+func (hd *hostDiscovery) sendUdpProbes() {
     ips      := *hd.ips
     delays   := generators.NewDelayIter(hd.delay, int(ips.Total()))
     socket   := sockets.NewL3Socket(hd.iface)

--- a/engines/hostdisc/host_disc.go
+++ b/engines/hostdisc/host_disc.go
@@ -52,7 +52,7 @@ type hostInfo struct {
 
 
 
-type HostDiscovery struct {
+type hostDiscovery struct {
     activeIPs      map[[4]byte]hostInfo
     delay          string
     ips           *generators.Ipv4Iter
@@ -69,8 +69,8 @@ type HostDiscovery struct {
 
 
 
-func newHostDisc(argList []string) *HostDiscovery {
-    var args *HostDiscArgs = ParseNetMapArgs(argList)
+func newHostDisc(argList []string) *hostDiscovery {
+    var args *hostDiscArgs = ParseNetMapArgs(argList)
 
 	var iface *net.Interface
 	if args.Iface == nil {
@@ -81,7 +81,7 @@ func newHostDisc(argList []string) *HostDiscovery {
 
 	cidr := ifaceinfo.MustCIDR(iface)
 
-    return &HostDiscovery{
+    return &hostDiscovery{
         activeIPs: make(map[[4]byte]hostInfo),
         ips:       generators.NewIpv4Iter(cidr, args.Range),
         myIP:      ifaceinfo.MustIPv4(iface),
@@ -93,7 +93,7 @@ func newHostDisc(argList []string) *HostDiscovery {
 
 
 
-func protoFlags(args *HostDiscArgs, iface *net.Interface) protocols {
+func protoFlags(args *hostDiscArgs, iface *net.Interface) protocols {
     isLocal := true
 
     if args.Range != nil {
@@ -121,7 +121,7 @@ func protoFlags(args *HostDiscArgs, iface *net.Interface) protocols {
 
 
 
-func (hd *HostDiscovery) execute() {
+func (hd *hostDiscovery) execute() {
     hd.displayExecInfo()
     hd.startPacketProcessor()
     hd.createGoroutines()
@@ -132,7 +132,7 @@ func (hd *HostDiscovery) execute() {
 
 
 
-func (hd *HostDiscovery) displayExecInfo() {
+func (hd *hostDiscovery) displayExecInfo() {
     var protoc []string
     if hd.protocols.arp  { protoc = append(protoc, "ARP") }
     if hd.protocols.icmp { protoc = append(protoc, "ICMP") }
@@ -152,7 +152,7 @@ func (hd *HostDiscovery) displayExecInfo() {
 
 
 
-func (hd *HostDiscovery) resolveNames() {
+func (hd *hostDiscovery) resolveNames() {
     hd.mut.Lock()
     defer hd.mut.Unlock()
 
@@ -167,7 +167,7 @@ func (hd *HostDiscovery) resolveNames() {
 
 
 
-func (hd *HostDiscovery) displayResult() {
+func (hd *hostDiscovery) displayResult() {
 	hd.mut.Lock()
     defer hd.mut.Unlock()
 

--- a/engines/hostdisc/host_disc.go
+++ b/engines/hostdisc/host_disc.go
@@ -76,7 +76,7 @@ func newHostDisc(argList []string) *hostDiscovery {
 	if args.Iface == nil {
 		iface = sysinfo.MustDefaultInterface()
 	} else {
-		iface = conv.MustGetIface(*args.Iface)
+		iface = conv.MustStrToIface(*args.Iface)
 	}
 
 	cidr := ifaceinfo.MustCIDR(iface)

--- a/engines/ifconf/arg_parser.go
+++ b/engines/ifconf/arg_parser.go
@@ -15,12 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org>.
  */
 
-package beacon
+package ifconf
 
 import (
 	"fmt"
-	"net"
-	"offscan/internal/conv"
 	"offscan/internal/utils"
 	"os"
 
@@ -29,42 +27,28 @@ import (
 
 
 
-type bcFloodArgs struct {
-	Ssid    string
-	Iface   *net.Interface
-	Channel int
+type ifConfArgs struct {
+	Iface  string  `short:"i" long:"iface" description:"Interface to set mode" required:"true"`
+	Man    bool    `long:"man" description:"Set interface on managed mode"`
+    Mon    bool    `long:"mon" description:"Set interface on monitor mode"`
 }
 
 
 
-type Args struct {
-    Ssid    string `short:"s" long:"ssid" description:"SSID/Network name" required:"true"`
-    Iface   string `short:"i" long:"iface" description:"Interface to be used" required:"true"`
-    Channel int    `short:"c" long:"channel" description:"Channel" required:"true"`
-}
-
-
-
-func parseArgs(argList []string) *bcFloodArgs {
-    var opts Args
+func parseIfConfigArgs(args []string) *ifConfArgs {
+    var opts ifConfArgs
 
 	parser := flags.NewParser(&opts, flags.HelpFlag)
-    _, err := parser.ParseArgs(argList)
+    _, err := parser.ParseArgs(args)
 
 	if err != nil {
-		if flags.WroteHelp(err) {
+        if flags.WroteHelp(err) {
 			fmt.Printf("%v", err)
 			os.Exit(0)
 		}
-		
-		utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
+        
+        utils.Abort(fmt.Sprintf("Unable to create argument parser: %v", err))
     }
 
-	bcArgs := &bcFloodArgs{
-		Ssid:    opts.Ssid,
-		Iface:   conv.MustGetIface(opts.Iface),
-		Channel: opts.Channel,
-	}
-
-	return bcArgs
+	return &opts
 }

--- a/engines/ifconf/ifconf.go
+++ b/engines/ifconf/ifconf.go
@@ -19,6 +19,7 @@ package ifconf
 
 import (
 	"fmt"
+	"offscan/internal/conv"
 	"offscan/internal/utils"
 	"os/exec"
 	"time"
@@ -68,6 +69,8 @@ func (ic *ifaceConfig) validateFlags() {
 	if ic.args.Mon && ic.args.Man {
 		utils.Abort("Select only one mode: --mon or --man")
 	}
+
+	conv.MustStrToIface(ic.args.Iface)
 }
 
 

--- a/engines/ifconf/ifconf.go
+++ b/engines/ifconf/ifconf.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025 Oliver R. Calazans Jeronimo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org>.
+ */
+
+package ifconf
+
+import (
+	"fmt"
+	"offscan/internal/utils"
+	"os/exec"
+	"time"
+)
+
+
+
+func Run(args []string) {
+    newIfaceConfig(args).execute()
+}
+
+
+
+type ifaceConfig struct {
+	args  *ifConfArgs
+}
+
+
+
+func newIfaceConfig(args []string) *ifaceConfig {
+	return &ifaceConfig{
+		args: parseIfConfigArgs(args),
+	}
+}
+
+
+
+func (ic *ifaceConfig) execute() {
+	ic.validateFlags()
+
+	if ic.args.Mon {
+		ic.setMonitorMode()
+	}
+
+	if ic.args.Man {
+		ic.setManagedMode()
+	}
+}
+
+
+
+func (ic *ifaceConfig) validateFlags() {
+	if !ic.args.Mon && !ic.args.Man {
+		utils.Abort("It's necessary to select a mode: --mon or --man")
+	}
+
+	if ic.args.Mon && ic.args.Man {
+		utils.Abort("Select only one mode: --mon or --man")
+	}
+}
+
+
+
+func handler(cmd *exec.Cmd) *string {
+    err := cmd.Run()
+    
+	if err != nil {
+        msg := fmt.Sprintf("%s", err)
+        return &msg
+    }
+    
+	time.Sleep(1e8)
+    return nil
+}
+
+
+
+func (ic *ifaceConfig) setIfaceDown() {
+	cmd := exec.Command("sudo", "ip", "link", "set", ic.args.Iface, "down")
+	
+	if err := handler(cmd); err != nil {
+		utils.Abort(
+			fmt.Sprintf("Unable to set interface %s down: %v", ic.args.Iface, err))
+	}
+}
+
+
+
+func (ic *ifaceConfig) setIfaceUp() {
+	cmd := exec.Command("sudo", "ip", "link", "set", ic.args.Iface, "up")
+	
+	if err := handler(cmd); err != nil {
+		utils.Abort(
+			fmt.Sprintf("Unable to set interface %s up: %v", ic.args.Iface, err))
+	}
+}
+
+
+
+func (ic *ifaceConfig) delIface() {
+	cmd := exec.Command("sudo", "iw", "dev", ic.args.Iface, "del")
+	
+	if err := handler(cmd); err != nil {
+		utils.Abort(
+			fmt.Sprintf("Unable to delete interface %s: %v", ic.args.Iface, err))
+	}
+}
+
+
+
+func (ic *ifaceConfig) createIface(mode string) {
+	cmd := exec.Command("sudo", "iw", "phy", "phy0", "interface", "add", ic.args.Iface, "type", mode)
+	
+	if err := handler(cmd); err != nil {
+		utils.Abort(
+			fmt.Sprintf("Unable to create interface %s on %s mode: %v", ic.args.Iface, mode, err))
+	}
+}
+
+
+
+func (ic *ifaceConfig) setMonitorMode() {
+	ic.setIfaceDown()
+	ic.delIface()
+	ic.createIface("monitor")
+	ic.setIfaceUp()	
+}
+
+
+
+func (ic *ifaceConfig) setManagedMode() {
+	ic.setIfaceDown()
+	ic.delIface()
+	ic.createIface("managed")
+	ic.setIfaceUp()	
+}

--- a/engines/netinfo/arg_parser.go
+++ b/engines/netinfo/arg_parser.go
@@ -27,14 +27,14 @@ import (
 
 
 
-type NetInfoArgs struct {
+type netInfoArgs struct {
     Iface string `short:"i" long:"iface" description:"Define a network interface to get information (optional)" value-name:"IFACE"`
 }
 
 
 
-func ParseNetInfoArgs(argList []string) *NetInfoArgs {
-    var opts NetInfoArgs
+func ParseNetInfoArgs(argList []string) *netInfoArgs {
+    var opts netInfoArgs
 
 	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(argList)

--- a/engines/netinfo/net_info.go
+++ b/engines/netinfo/net_info.go
@@ -60,7 +60,7 @@ func newNetInfo(argList []string) *networkInfo {
     if  args.Iface == "" {
         ifaceList = sysinfo.MustAllIfaces()
     } else {
-        ifaceList = append(ifaceList, *conv.MustGetIface(args.Iface))
+        ifaceList = append(ifaceList, *conv.MustStrToIface(args.Iface))
     }
 
     return &networkInfo{

--- a/engines/netinfo/net_info.go
+++ b/engines/netinfo/net_info.go
@@ -36,7 +36,7 @@ func Run(args []string) {
 
 
 
-type NetworkInfo struct {
+type networkInfo struct {
     ifaceList   []net.Interface
     current     *net.Interface
     state       string
@@ -53,7 +53,7 @@ type NetworkInfo struct {
 
 
 
-func newNetInfo(argList []string) *NetworkInfo {
+func newNetInfo(argList []string) *networkInfo {
 	args := ParseNetInfoArgs(argList)
     var ifaceList []net.Interface
 
@@ -63,14 +63,14 @@ func newNetInfo(argList []string) *NetworkInfo {
         ifaceList = append(ifaceList, *conv.MustGetIface(args.Iface))
     }
 
-    return &NetworkInfo{
+    return &networkInfo{
         ifaceList: ifaceList,
     }
 }
 
 
 
-func (ni *NetworkInfo) execute() {
+func (ni *networkInfo) execute() {
     for idx, iface := range ni.ifaceList {
 		ni.current = &iface
         
@@ -90,7 +90,7 @@ func (ni *NetworkInfo) execute() {
 
 
 
-func (ni *NetworkInfo) setState() {
+func (ni *networkInfo) setState() {
     state, err := ifaceinfo.State(ni.current)
     
 	if err != nil {
@@ -102,19 +102,19 @@ func (ni *NetworkInfo) setState() {
 
 
 
-func (ni *NetworkInfo) setType() {
+func (ni *networkInfo) setType() {
     ni.ifType = ifaceinfo.Type(ni.current)
 }
 
 
 
-func (ni *NetworkInfo) setMAC() {
+func (ni *networkInfo) setMAC() {
     ni.mac = ni.current.HardwareAddr.String()    
 }
 
 
 
-func (ni *NetworkInfo) setIP() {
+func (ni *networkInfo) setIP() {
     ip, err := ifaceinfo.IPv4(ni.current)
     
 	if err != nil {
@@ -126,7 +126,7 @@ func (ni *NetworkInfo) setIP() {
 
 
 
-func (ni *NetworkInfo) setCIDR() {
+func (ni *networkInfo) setCIDR() {
     cidr, err := ifaceinfo.CIDR(ni.current)
     
 	if err != nil {
@@ -138,7 +138,7 @@ func (ni *NetworkInfo) setCIDR() {
 
 
 
-func (ni *NetworkInfo) setHostLen() {
+func (ni *networkInfo) setHostLen() {
     parts := strings.Split(ni.cidr, "/")
     
 	if len(parts) < 2 {
@@ -164,13 +164,13 @@ func (ni *NetworkInfo) setHostLen() {
 
 
 
-func (ni *NetworkInfo) setMTU() {
+func (ni *networkInfo) setMTU() {
     ni.mtu = fmt.Sprintf("%d", ni.current.MTU)
 }
 
 
 
-func (ni *NetworkInfo) setGatewayMAC() {
+func (ni *networkInfo) setGatewayMAC() {
     mac, err := ifaceinfo.GatewayMAC(ni.current)
 
     if err != nil {
@@ -182,7 +182,7 @@ func (ni *NetworkInfo) setGatewayMAC() {
 
 
 
-func (ni *NetworkInfo) setGatewayIP() {
+func (ni *networkInfo) setGatewayIP() {
     ip, err := ifaceinfo.GatewayIP(ni.current)
     
 	if err != nil {
@@ -194,7 +194,7 @@ func (ni *NetworkInfo) setGatewayIP() {
 
 
 
-func (ni *NetworkInfo) setBroadcast() {
+func (ni *networkInfo) setBroadcast() {
     if ni.ifType == "Loopback" {
         ni.broadcast = "None"
         return
@@ -211,7 +211,7 @@ func (ni *NetworkInfo) setBroadcast() {
 
 
 
-func (ni *NetworkInfo) displayInfo(index int) {
+func (ni *networkInfo) displayInfo(index int) {
     fmt.Printf("#%d Interface: %s - State: %s\n", index, ni.current.Name, ni.state)
     fmt.Println("  - Type.......:", ni.ifType)
     fmt.Println("  - MAC........:", ni.mac)

--- a/engines/portscan/arg_parser.go
+++ b/engines/portscan/arg_parser.go
@@ -27,9 +27,9 @@ import (
 
 
 
-type PortScanArgs struct {
+type portScanArgs struct {
     TargetIP   string  `short:"t" long:"target" description:"Target IP" required:"true"`
-    Ports     *string `short:"p" long:"ports" description:"Specific ports or ranges (e.g., 22,80 or 20-50)"`
+    Ports     *string  `short:"p" long:"ports" description:"Specific ports or ranges (e.g., 22,80 or 20-50)"`
     Random     bool    `short:"r" long:"random" description:"Scan ports in random order"`
     Delay      string  `short:"d" long:"delay" default:"0.03" description:"Delay between packets (seconds)"`
     UDP        bool    `short:"U" long:"udp" description:"Scan UDP ports"`
@@ -37,8 +37,8 @@ type PortScanArgs struct {
 
 
 
-func ParsePortScanArgs(args []string) *PortScanArgs {
-    var opts PortScanArgs
+func parsePortScanArgs(args []string) *portScanArgs {
+    var opts portScanArgs
 
 	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)

--- a/engines/portscan/portscan.go
+++ b/engines/portscan/portscan.go
@@ -44,7 +44,7 @@ func Run(args []string) {
 
 
 
-type PortScanner struct {
+type portScanner struct {
     iface      *net.Interface
     myIP        net.IP
     targetIP    net.IP
@@ -60,13 +60,13 @@ type PortScanner struct {
 
 
 
-func newPortScanner(argList []string) *PortScanner {
-	args  := ParsePortScanArgs(argList)
+func newPortScanner(argList []string) *portScanner {
+	args  := parsePortScanArgs(argList)
 	dstIP := conv.MustStrToIPv4(args.TargetIP)
 	iface := netroute.MustRouteIfaceForDstIP(dstIP)
 	myIP  := ifaceinfo.MustIPv4(iface)
     
-    return &PortScanner{
+    return &portScanner{
         iface:      iface,
         myIP:       myIP,
         targetIP:   dstIP,
@@ -80,7 +80,7 @@ func newPortScanner(argList []string) *PortScanner {
 
 
 
-func (ps *PortScanner) execute() {
+func (ps *portScanner) execute() {
     ps.displayInfo()
     ps.startPacketProcessor()
     ps.sendProbes()
@@ -90,7 +90,7 @@ func (ps *PortScanner) execute() {
 
 
 
-func (ps *PortScanner) displayInfo() {
+func (ps *portScanner) displayInfo() {
     proto := "TCP"
 
 	if ps.udp {
@@ -104,7 +104,7 @@ func (ps *PortScanner) displayInfo() {
 
 
 
-func (ps *PortScanner) startPacketProcessor() {
+func (ps *portScanner) startPacketProcessor() {
     ps.sniffer = pktsniffer.NewSniffer(ps.iface, ps.getBPFFilter(), false)
     packetCh  := ps.sniffer.Start()
 
@@ -129,7 +129,7 @@ func (ps *PortScanner) startPacketProcessor() {
 
 
 
-func (ps *PortScanner) getBPFFilter() string {
+func (ps *portScanner) getBPFFilter() string {
     if ps.udp {
         return fmt.Sprintf(
 			"udp and dst host %s and src host %s",
@@ -145,7 +145,7 @@ func (ps *PortScanner) getBPFFilter() string {
 
 
 
-func (ps *PortScanner) dissectAndUpdate(dissector *pktdissector.PacketDissector, tempPorts map[uint16]bool, pkt []byte) {
+func (ps *portScanner) dissectAndUpdate(dissector *pktdissector.PacketDissector, tempPorts map[uint16]bool, pkt []byte) {
     dissector.UpdatePkt(pkt)
     var port uint16
     var ok bool
@@ -163,14 +163,14 @@ func (ps *PortScanner) dissectAndUpdate(dissector *pktdissector.PacketDissector,
 
 
 
-func (ps *PortScanner) stopPacketProcessor() {
+func (ps *portScanner) stopPacketProcessor() {
     ps.sniffer.Stop()
     ps.wg.Wait()
 }
 
 
 
-func (ps *PortScanner) sendProbes() {
+func (ps *portScanner) sendProbes() {
     socket  := sockets.NewL3Socket(ps.iface)
     randGen := generators.NewRandomValues()
 
@@ -185,7 +185,7 @@ func (ps *PortScanner) sendProbes() {
 
 
 
-func (ps *PortScanner) sendTcpProbes(socket *sockets.Layer3Socket, randGen *generators.RandomValues) {
+func (ps *portScanner) sendTcpProbes(socket *sockets.Layer3Socket, randGen *generators.RandomValues) {
     portIter  := generators.NewPortIter(ps.ports, ps.random)
     delayIter := generators.NewDelayIter(ps.delay, portIter.Len())
     builder   := pktbuilder.NewTcpPkt()
@@ -207,7 +207,7 @@ func (ps *PortScanner) sendTcpProbes(socket *sockets.Layer3Socket, randGen *gene
 
 
 
-func (ps *PortScanner) sendUdpProbes(socket *sockets.Layer3Socket, randGen *generators.RandomValues) {
+func (ps *portScanner) sendUdpProbes(socket *sockets.Layer3Socket, randGen *generators.RandomValues) {
     payloads  := pktbuilder.NewUdpPayloads(ps.myIP)
     entries   := payloads.Entries()
     delayIter := generators.NewDelayIter(ps.delay, len(entries))
@@ -227,7 +227,7 @@ func (ps *PortScanner) sendUdpProbes(socket *sockets.Layer3Socket, randGen *gene
 
 
 
-func (ps *PortScanner) displayResult() {
+func (ps *portScanner) displayResult() {
     deviceName := sysinfo.GetHostName(ps.targetIP.String())
     ports      := ps.formatPorts()
     
@@ -237,7 +237,7 @@ func (ps *PortScanner) displayResult() {
 
 
 
-func (ps *PortScanner) formatPorts() string {
+func (ps *portScanner) formatPorts() string {
     ps.mut.Lock()
     defer ps.mut.Unlock()
 

--- a/engines/wifimap/arg_parser.go
+++ b/engines/wifimap/arg_parser.go
@@ -26,14 +26,14 @@ import (
 )
 
 
-type WmapArgs struct {
+type wmapArgs struct {
     Iface   string `short:"i" long:"iface" description:"Interface to be used to get the beacons" required:"true"`
 }
 
 
 
-func ParseWmapArgs(args []string) *WmapArgs {
-    var opts WmapArgs
+func ParseWmapArgs(args []string) *wmapArgs {
+    var opts wmapArgs
     
 	parser := flags.NewParser(&opts, flags.HelpFlag)
     _, err := parser.ParseArgs(args)

--- a/engines/wifimap/monsniff.go
+++ b/engines/wifimap/monsniff.go
@@ -34,8 +34,8 @@ import (
 
 type MonitorSniff struct {
     iface     *net.Interface
-    wifisBuf  *map[string]WifiData
-    buffer     map[string]WifiData      
+    wifisBuf  *map[string]wifiData
+    buffer     map[string]wifiData      
     mut        sync.Mutex
     cancel     chan struct{}
     wg         sync.WaitGroup
@@ -45,11 +45,11 @@ type MonitorSniff struct {
 
 
 
-func NewMonitorSniff(iface *net.Interface, wifisBuf *map[string]WifiData) *MonitorSniff {
+func NewMonitorSniff(iface *net.Interface, wifisBuf *map[string]wifiData) *MonitorSniff {
     return &MonitorSniff{
         iface:    iface,
         wifisBuf: wifisBuf,
-        buffer:   make(map[string]WifiData),
+        buffer:   make(map[string]wifiData),
         cancel:   make(chan struct{}),
     }
 }
@@ -75,7 +75,7 @@ func (m *MonitorSniff) startBeaconProcessor() {
     go func() {
         defer m.wg.Done()
 
-        tempBuf := make(map[string]WifiData)
+        tempBuf := make(map[string]wifiData)
         
 		for {
 			pkt, ok := <-packetCh
@@ -97,7 +97,7 @@ func getBPFFilter() string {
 
 
 
-func (m *MonitorSniff) dissectAndUpdate(tempBuf map[string]WifiData, beacon []byte) {
+func (m *MonitorSniff) dissectAndUpdate(tempBuf map[string]wifiData, beacon []byte) {
     info, ok := m.dissec.DissecBeacon(beacon)
     
 	if !ok || len(info) < 4 {
@@ -126,7 +126,7 @@ func getFrequency(chnl uint8) string {
 
 
 func (m *MonitorSniff) addInfo(
-	tempBuf  map[string]WifiData, 
+	tempBuf  map[string]wifiData, 
 	ssid     string, 
 	bssid    string, 
 	chnl     uint8, 
@@ -144,7 +144,7 @@ func (m *MonitorSniff) addInfo(
         tempBuf[ssid]          = existing
 
     } else {
-        tempBuf[ssid] = WifiData{
+        tempBuf[ssid] = wifiData{
    			BSSIDs:   map[string]struct{}{bssid: {}},
 			Channel:  chnl,
             Freq:     freq,
@@ -204,11 +204,11 @@ func (m *MonitorSniff) sendData() {
     m.mut.Lock()
     defer m.mut.Unlock()
 
-    *m.wifisBuf = make(map[string]WifiData)
+    *m.wifisBuf = make(map[string]wifiData)
 
     for k, v := range m.buffer {
         (*m.wifisBuf)[k] = v
     }
 
-    m.buffer = make(map[string]WifiData)
+    m.buffer = make(map[string]wifiData)
 }

--- a/engines/wifimap/wifimap.go
+++ b/engines/wifimap/wifimap.go
@@ -52,7 +52,7 @@ func newWifiMapper(argList []string) *WifiMapper {
 
     return &WifiMapper{
         wifis: make(map[string]wifiData),
-        iface: conv.MustGetIface(args.Iface),
+        iface: conv.MustStrToIface(args.Iface),
     }
 }
 

--- a/engines/wifimap/wifimap.go
+++ b/engines/wifimap/wifimap.go
@@ -32,7 +32,7 @@ func Run(args []string) {
 }
 
 
-type WifiData struct {
+type wifiData struct {
     BSSIDs   map[string]struct{}
     Channel  uint8
     Freq     string
@@ -41,7 +41,7 @@ type WifiData struct {
 
 
 type WifiMapper struct {
-    wifis   map[string]WifiData
+    wifis   map[string]wifiData
     iface  *net.Interface
 }
 
@@ -51,7 +51,7 @@ func newWifiMapper(argList []string) *WifiMapper {
 	args := ParseWmapArgs(argList)
 
     return &WifiMapper{
-        wifis: make(map[string]WifiData),
+        wifis: make(map[string]wifiData),
         iface: conv.MustGetIface(args.Iface),
     }
 }
@@ -82,7 +82,7 @@ func (wm *WifiMapper) displayResults() {
     }
 
     wifis   := wm.wifis
-    wm.wifis = make(map[string]WifiData)
+    wm.wifis = make(map[string]wifiData)
 
     wm.displayHeader(maxLen)
 
@@ -114,7 +114,7 @@ func (wm *WifiMapper) displayHeader(maxLen int) {
 
 
 
-func (wm *WifiMapper) displayWifiInfo(ssid string, info *WifiData, maxLen int) {
+func (wm *WifiMapper) displayWifiInfo(ssid string, info *wifiData, maxLen int) {
     bssidStrs := make([]string, 0, len(info.BSSIDs))
     for bssid := range info.BSSIDs {
         bssidStrs = append(bssidStrs, bssid)

--- a/internal/conv/str_to_iface.go
+++ b/internal/conv/str_to_iface.go
@@ -25,11 +25,11 @@ import (
 
 
 
-func MustGetIface(ifaceName string) *net.Interface {
+func MustStrToIface(ifaceName string) *net.Interface {
     iface, err := net.InterfaceByName(ifaceName)
     
 	if err != nil {
-        utils.Abort(fmt.Sprintf("Erro ao obter interface %s: %v", ifaceName, err))
+        utils.Abort(fmt.Sprintf("Unable to get interface %s: %v", ifaceName, err))
     }
     
 	return iface

--- a/internal/conv/str_to_ip.go
+++ b/internal/conv/str_to_ip.go
@@ -29,7 +29,7 @@ func MustStrToIPv4(s string) net.IP {
     ip := net.ParseIP(s)
     
 	if ip == nil {
-        utils.Abort(fmt.Sprintf("invalid IP address: %s", s))
+        utils.Abort(fmt.Sprintf("Invalid IP address: %s", s))
     }
     
 	return ip

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"offscan/engines/beacon"
 	"offscan/engines/deauth"
 	"offscan/engines/hostdisc"
+	"offscan/engines/ifconf"
 	"offscan/engines/netinfo"
 	"offscan/engines/portscan"
 	"offscan/engines/wifimap"
@@ -47,6 +48,10 @@ var registry = map[string]CommandHandler{
 	"deauth": {
 		Desc: "Deauthentication attack",
 		Run:  deauth.Run,
+	},
+	"ifconf": {
+		Desc: "Interface Configuration",
+		Run:  ifconf.Run,
 	},
 	"info": {
 		Desc: "Network Information",


### PR DESCRIPTION
This PR adds a function to change a Wi-Fi interface (e.g., `wlan0`) from managed mode (default) to monitor mode (required for packet capture or injection).

This is needed because some features of the project require monitor mode to work.

The implementation uses standard Linux commands:
- `ip` to bring the interface `up`/`down`
-  `iw` to change the interface type (`managed` or `monitor`)

The function checks the current state, applies the commands in the correct order, and handles errors.