### PR TITLE
Refac Host Discovery and Beacon Dissector

### DIFF
--- a/engines/hostdisc/hd_pkt_send.go
+++ b/engines/hostdisc/hd_pkt_send.go
@@ -29,8 +29,7 @@ import (
 
 
 func (hd *hostDiscovery) sendProbes() {
-    ips     := *hd.ips
-    delays  := generators.NewDelayIter(hd.delay, int(ips.Total()))
+    delays  := generators.NewDelayIter(hd.delay, int(hd.ips.Total()))
     socket  := sockets.NewL3Socket(hd.iface)
     srcMAC  := hd.iface.HardwareAddr
     randGen := generators.NewRandomValues()
@@ -38,29 +37,26 @@ func (hd *hostDiscovery) sendProbes() {
     var pktErr uint16 = 0
 
 	for {
-        dstIP, ok1 := hd.ips.Next()
-        delay, ok2 := delays.Next()
+        dstIP, hasIP    := hd.ips.Next()
+        delay, hasDelay := delays.Next()
         
-        if !ok1 || !ok2  {
+        if !hasIP || !hasDelay  {
             break
         }
 
         if hd.protocols.arp {
-            if ok := hd.sendArpProbe(socket, dstIP, srcMAC); ok == false {
-                pktErr++
-            }
+            ok := hd.sendArpProbe(socket, dstIP, srcMAC)
+            if !ok { pktErr++ }
         }
 
         if hd.protocols.icmp {
-            if ok := hd.sendIcmpProbe(socket, dstIP); ok == false {
-                pktErr++
-            }
+            ok := hd.sendIcmpProbe(socket, dstIP)
+            if !ok { pktErr++ }
         }
 
         if hd.protocols.tcp {
-            if ok := hd.sendTcpProbe(socket, dstIP, randGen.RandomPort()); ok == false {
-                pktErr++
-            }
+            ok := hd.sendTcpProbe(socket, dstIP, randGen.RandomPort())
+            if !ok { pktErr++ }
         }
 
         time.Sleep(time.Duration(delay * float64(time.Second)))

--- a/engines/hostdisc/hd_pkt_send.go
+++ b/engines/hostdisc/hd_pkt_send.go
@@ -19,120 +19,112 @@ package hostdisc
 
 import (
 	"fmt"
+	"net"
 	"offscan/internal/generators"
 	"offscan/internal/pktbuilder"
 	"offscan/internal/sockets"
-	"offscan/internal/utils"
 	"time"
 )
 
 
 
-func (hd *hostDiscovery) createGoroutines() {
-    if hd.protocols.arp {
-        hd.wgSocks.Add(1)
-        go hd.sendProbes("arp")
-    }
-
-    if hd.protocols.icmp {
-        hd.wgSocks.Add(1)
-        go hd.sendProbes("icmp")
-    }
-    
-	if hd.protocols.tcp {
-        hd.wgSocks.Add(1)
-        go hd.sendProbes("tcp")
-    }
-    
-	if hd.protocols.udp {
-        hd.wgSocks.Add(1)
-        go hd.sendProbes("udp")
-    }
-
-    hd.wgSocks.Wait()
-    time.Sleep(3 * time.Second)
-}
-
-
-
-func (hd *hostDiscovery) sendProbes(proto string) {
-    defer hd.wgSocks.Done()
-
-	switch proto {
-    case "arp":  hd.sendArpProbes()
-    case "icmp": hd.sendIcmpProbes()
-	case "tcp":  hd.sendTcpProbes()
-	default:     utils.Abort(fmt.Sprintf("Unknown protocol: %s", proto))
-    }
-    
-}
-
-
-
-func (hd *hostDiscovery) sendArpProbes() {
-    ips    := *hd.ips
-    delays := generators.NewDelayIter(hd.delay, int(ips.Total()))
-    socket := sockets.NewL3Socket(hd.iface)
-    srcMAC := hd.iface.HardwareAddr
-        
-    for {
-        dstIP, ok1 := ips.Next()
-        delay, ok2 := delays.Next()
-        
-        if !ok1 || !ok2  {
-            break
-        }
-
-        if pkt, err := pktbuilder.ArpRequest(srcMAC, hd.myIP, dstIP); err == nil {
-            socket.SendTo(pkt, dstIP)
-            time.Sleep(time.Duration(delay * float64(time.Second)))
-        }
-    }
-}
-
-
-
-func (hd *hostDiscovery) sendIcmpProbes() {
-    ips    := *hd.ips
-    delays := generators.NewDelayIter(hd.delay, int(ips.Total()))
-    socket := sockets.NewL3Socket(hd.iface)
-    
-    for {
-        dstIP, ok1 := ips.Next()
-        delay, ok2 := delays.Next()
-        
-        if !ok1 || !ok2  {
-            break
-        }
-
-        if pkt, err := pktbuilder.PingPkt(hd.myIP, dstIP); err == nil {
-            socket.SendTo(pkt, dstIP)
-            time.Sleep(time.Duration(delay * float64(time.Second)))
-        }
-    }
-}
-
-
-
-func (hd *hostDiscovery) sendTcpProbes() {
+func (hd *hostDiscovery) sendProbes() {
     ips     := *hd.ips
     delays  := generators.NewDelayIter(hd.delay, int(ips.Total()))
     socket  := sockets.NewL3Socket(hd.iface)
+    srcMAC  := hd.iface.HardwareAddr
     randGen := generators.NewRandomValues()
     
-    for {
-        dstIP, ok1 := ips.Next()
+    var pktErr uint16 = 0
+
+	for {
+        dstIP, ok1 := hd.ips.Next()
         delay, ok2 := delays.Next()
         
         if !ok1 || !ok2  {
             break
         }
 
-        srcPort := randGen.RandomPort()
-        
-        if pkt, err := pktbuilder.TcpSynPkt(hd.myIP, dstIP, srcPort, 80); err == nil {
-            socket.SendTo(pkt, dstIP)
-            time.Sleep(time.Duration(delay * float64(time.Second)))
+        if hd.protocols.arp {
+            if ok := hd.sendArpProbe(socket, dstIP, srcMAC); ok == false {
+                pktErr++
+            }
         }
+
+        if hd.protocols.icmp {
+            if ok := hd.sendIcmpProbe(socket, dstIP); ok == false {
+                pktErr++
+            }
+        }
+
+        if hd.protocols.tcp {
+            if ok := hd.sendTcpProbe(socket, dstIP, randGen.RandomPort()); ok == false {
+                pktErr++
+            }
+        }
+
+        time.Sleep(time.Duration(delay * float64(time.Second)))
     }
+
+    fmt.Printf("[!] Packets not sent: %d\n", pktErr)
+    time.Sleep(2 * time.Second)
+}
+
+
+
+func (hd *hostDiscovery) sendArpProbe(
+    socket  *sockets.Layer3Socket,
+    dstIP    net.IP,
+    srcMAC   net.HardwareAddr,
+
+) bool {
+
+    pkt, err := pktbuilder.ArpRequest(srcMAC, hd.myIP, dstIP)
+
+    if err != nil {
+        return false
+    }
+    
+    socket.SendTo(pkt, dstIP)
+    time.Sleep(50 * time.Millisecond)
+    return true
+}
+
+
+
+func (hd *hostDiscovery) sendIcmpProbe(
+    socket  *sockets.Layer3Socket,
+    dstIP    net.IP,
+
+) bool {
+
+    pkt, err := pktbuilder.PingPkt(hd.myIP, dstIP)
+    
+    if err != nil {
+        return false
+    }
+    
+    socket.SendTo(pkt, dstIP)
+    time.Sleep(50 * time.Millisecond)
+    return true
+}
+
+
+
+func (hd *hostDiscovery) sendTcpProbe(
+    socket  *sockets.Layer3Socket,
+    dstIP    net.IP,
+    srcPort  uint16,
+
+) bool {
+    
+    pkt, err := pktbuilder.TcpSynPkt(hd.myIP, dstIP, srcPort, 80)
+
+    if err != nil {
+        return false
+    }
+
+    socket.SendTo(pkt, dstIP)
+    time.Sleep(50 * time.Millisecond)
+    return true
 }

--- a/engines/hostdisc/host_disc.go
+++ b/engines/hostdisc/host_disc.go
@@ -123,7 +123,7 @@ func protoFlags(args *hostDiscArgs, iface *net.Interface) protocols {
 func (hd *hostDiscovery) execute() {
     hd.displayExecInfo()
     hd.startPacketProcessor()
-    hd.createGoroutines()
+    hd.sendProbes()
     hd.stopPacketProcessor()
     hd.resolveNames()
     hd.displayResult()

--- a/engines/wifimap/arg_parser.go
+++ b/engines/wifimap/arg_parser.go
@@ -27,7 +27,7 @@ import (
 
 
 type wmapArgs struct {
-    Iface   string `short:"i" long:"iface" description:"Interface to be used to get the beacons" required:"true"`
+    Iface  string  `short:"i" long:"iface" description:"Interface to be used to get the beacons" required:"true"`
 }
 
 

--- a/engines/wifimap/monsniff.go
+++ b/engines/wifimap/monsniff.go
@@ -108,8 +108,9 @@ func (m *MonitorSniff) dissectAndUpdate(tempBuf map[string]wifiData, beacon []by
     sec      := info[3]
     bssid    := conv.MustStrToMac(bssidStr)
     freq     := getFrequency(chnl)
+    std      := info[4]
 
-    m.addInfo(tempBuf, ssid, bssid.String(), chnl, freq, sec)
+    m.addInfo(tempBuf, ssid, bssid.String(), chnl, freq, sec, std)
 }
 
 
@@ -130,6 +131,7 @@ func (m *MonitorSniff) addInfo(
 	chnl     uint8, 
 	freq     string,
 	sec      string,
+    std      string,
 ) {
     existing, ok := tempBuf[ssid]
 
@@ -143,10 +145,11 @@ func (m *MonitorSniff) addInfo(
 
     } else {
         tempBuf[ssid] = wifiData{
-   			BSSIDs:   map[string]struct{}{bssid: {}},
-			Channel:  chnl,
-            Freq:     freq,
-            Sec:      sec,
+   			BSSIDs  : map[string]struct{}{bssid: {}},
+			Channel : chnl,
+            Freq    : freq,
+            Sec     : sec,
+            Std     : std,
         }
     }
 }

--- a/engines/wifimap/wifimap.go
+++ b/engines/wifimap/wifimap.go
@@ -37,6 +37,7 @@ type wifiData struct {
     Channel  uint8
     Freq     string
     Sec      string
+    Std      string
 }
 
 
@@ -101,15 +102,17 @@ func (wm *WifiMapper) displayResults() {
 
 
 func (wm *WifiMapper) displayHeader(maxLen int) {
-    fmt.Printf("\n%-*s  %-17s  %s  %s   %s\n",
-        maxLen, "SSID", "BSSID", "Channel", "Sec", "Freq")
+    fmt.Printf("\n%-*s  %-17s  %-4s  %s  %-8s  %s\n",
+        maxLen, "SSID", "BSSID", "Ch", "Freq", "Std", "Sec",
+    )
 
-		fmt.Printf("%s  %s  %s  %s  %s\n",
-        strings.Repeat("-", maxLen),
-        strings.Repeat("-", 17),
-        strings.Repeat("-", 7),
-        strings.Repeat("-", 4),
-        strings.Repeat("-", 4))
+	fmt.Printf("%s  %s  %s  %s  %s  %s\n",
+    strings.Repeat("-", maxLen),
+    strings.Repeat("-", 17),
+    strings.Repeat("-", 3),
+    strings.Repeat("-", 4),
+    strings.Repeat("-", 8),
+    strings.Repeat("-", 6))
 }
 
 
@@ -126,8 +129,8 @@ func (wm *WifiMapper) displayWifiInfo(ssid string, info *wifiData, maxLen int) {
         firstBSSID = bssidStrs[0]
     }
 
-    line := fmt.Sprintf("%-*s  %-17s  %-7d  %-4s  %sG\n",
-        maxLen, ssid, firstBSSID, info.Channel, info.Sec, info.Freq)
+    line := fmt.Sprintf("%-*s  %-17s  %-3d  %sG  %-8s  %-4s\n",
+        maxLen, ssid, firstBSSID, info.Channel, info.Freq, info.Std, info.Sec)
     
     fmt.Print(line)
 

--- a/internal/pktdissector/beacon_dissector.go
+++ b/internal/pktdissector/beacon_dissector.go
@@ -38,16 +38,17 @@ func DissecBeacon(data []byte) ([]string, bool) {
 		return nil, false
 	}
 
-    dot11, _ := dot11Layer.(*layers.Dot11)
+	dot11, _ := dot11Layer.(*layers.Dot11)
 
 	if dot11.Type != layers.Dot11TypeMgmtBeacon {
 		return nil, false
 	}
 
-	bssid   := dot11.Address3.String()
-	ssid    := "<hidden>"
-	channel := "0"
-	sec     := "Open"
+	bssid    := dot11.Address3.String()
+	ssid     := "<hidden>"
+	channel  := "0"
+	sec 	 := "Open"
+	standard := "802.11b/g"
 
 	for _, layer := range packet.Layers() {
 		if layer.LayerType() == layers.LayerTypeDot11InformationElement {
@@ -62,19 +63,115 @@ func DissecBeacon(data []byte) ([]string, bool) {
 				if len(ie.Info) > 0 {
 					channel = fmt.Sprintf("%d", ie.Info[0])
 				}
-			case 48: 
-				sec = "WPA2"
+			
+			case layers.Dot11InformationElementIDHTCapabilities:
+				standard = "802.11n"
+			case layers.Dot11InformationElementIDVHTCapabilities:
+				standard = "802.11ac"
+			case 255: // HE Capabilities (802.11ax / Wi-Fi 6)
+				if len(ie.Info) > 0 && ie.Info[0] == 35 {
+					standard = "802.11ax"
+				}
+
+			// Segurança Avançada (RSN)
+			case layers.Dot11InformationElementIDRSNInfo:
+				sec = parseRSN(ie.Info)
 			}
 		}
 	}
 
+	// Checagem de WEP/802.11w via Flags do Beacon
 	if beaconLayer := packet.Layer(layers.LayerTypeDot11MgmtBeacon); beaconLayer != nil {
 		b, _ := beaconLayer.(*layers.Dot11MgmtBeacon)
-
-        if sec == "Open" && (uint16(b.Flags) & 0x0010) != 0 {
+		
+		// Bit de Privacy indica criptografia (WEP se RSN não estiver presente)
+		if sec == "Open" && (uint16(b.Flags)&0x0010) != 0 {
 			sec = "WEP"
 		}
 	}
 
-	return []string{ssid, bssid, channel, sec}, true
+	return []string{ssid, bssid, channel, sec, standard}, true
 }
+
+// Função auxiliar para processar o campo RSN (WPA2/WPA3/Management Frame Protection)
+func parseRSN(data []byte) string {
+	if len(data) < 2 {
+		return "WPA2"
+	}
+
+	// O RSN possui uma estrutura fixa:
+	// Version (2 bytes)
+	// Group Cipher Suite (4 bytes)
+	// Pairwise Cipher Suite Count (2 bytes)
+	// Pairwise Cipher Suites (4 bytes cada)
+	// AKM Suite Count (2 bytes)
+	// AKM Suites (4 bytes cada)
+
+	var auth, cipher string
+	ptr := 2 // Pula a versão
+
+	// 1. Group Cipher (Multicast)
+	if len(data) >= ptr+4 {
+		cipher = decodeCipher(data[ptr : ptr+4])
+		ptr += 4
+	}
+
+	// 2. Pairwise Cipher Count (Unicast)
+	if len(data) >= ptr+2 {
+		count := int(data[ptr]) | int(data[ptr+1])<<8
+		ptr += 2
+		// Pegamos o primeiro Cipher Suite de Unicast disponível
+		if count > 0 && len(data) >= ptr+4 {
+			cipher = decodeCipher(data[ptr : ptr+4])
+			ptr += (count * 4)
+		}
+	}
+
+	// 3. AKM (Authentication Key Management)
+	if len(data) >= ptr+2 {
+		count := int(data[ptr]) | int(data[ptr+1])<<8
+		ptr += 2
+		if count > 0 && len(data) >= ptr+4 {
+			auth = decodeAKM(data[ptr : ptr+4])
+		}
+	}
+
+	// Verificação de 802.11w (Management Frame Protection)
+	// Fica nos RSN Capabilities (2 bytes após as listas acima)
+	mfp := ""
+	// O mapeamento exato de bits aqui é complexo, 
+	// mas simplificamos para o retorno:
+	if auth == "SAE (WPA3)" {
+		return "WPA3-" + cipher
+	}
+	
+	if auth == "" { auth = "PSK" }
+	return fmt.Sprintf("WPA2-%s-%s%s", auth, cipher, mfp)
+}
+
+func decodeCipher(suite []byte) string {
+	if suite[0] != 0x00 || suite[1] != 0x0F || suite[2] != 0xAC {
+		return "Unknown"
+	}
+	switch suite[3] {
+	case 2: return "TKIP"
+	case 4: return "CCMP(AES)"
+	case 5: return "WEP"
+	case 6: return "GCMP" // Comum em 802.11ad/ax
+	default: return "Reserved"
+	}
+}
+
+func decodeAKM(suite []byte) string {
+	if suite[0] != 0x00 || suite[1] != 0x0F || suite[2] != 0xAC {
+		return "Unknown"
+	}
+	switch suite[3] {
+	case 1: return "802.1x"
+	case 2: return "PSK"
+	case 8: return "SAE (WPA3)"
+	case 6: return "PSK-SHA256"
+	default: return "Reserved"
+	}
+}
+


### PR DESCRIPTION
This PR adds improvements in the **Host Discovery** and **Wi-Fi Mapper**.

### Changes
- **Host Discover**: Packet transmission has been refactored to send each protocol's packets serially instead of concurrently. Previously, a goroutine was spawned per protocol. The new approach sends packets to each target without saturating the bandwidth. Although it takes slightly longer to complete, it significantly improves precision and reliability.
- **Wi-Fi Mapper**: Added the standard protocol identifier for each network (e.g., 802.11w, 802.11ac, etc.). The dissector now retrieves the previously captured data and detects which standard protocol the access point (AP) is using.